### PR TITLE
feat: web accessibility via AccessKit DOM mirror (accesskit-web, WebA11y plugin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "accesskit",
  "accesskit_consumer 0.38.0",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
@@ -591,6 +592,12 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -2148,6 +2155,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2267,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -2598,6 +2624,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
@@ -4150,6 +4182,45 @@ checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
 
 [[package]]
 name = "wayland-backend"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3041,6 +3041,7 @@ dependencies = [
 name = "react-egui-app"
 version = "0.1.0"
 dependencies = [
+ "accesskit-web",
  "eframe",
  "egui",
  "egui_kittest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit-web"
+version = "0.1.0"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.38.0",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "accesskit_atspi_common"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,16 @@ react-egui = { path = "crates/react-egui", version = "0.1.0" }
 react-egui-macros = { path = "crates/react-egui-macros", version = "0.1.0" }
 react-egui-elements = { path = "crates/react-egui-elements", version = "0.1.0" }
 react-egui-app = { path = "crates/react-egui-app", version = "0.1.0" }
+accesskit-web = { path = "crates/accesskit-web", version = "0.1.0" }
 example-meta = { path = "examples/meta", version = "0.1.0" }
 
 egui = "0.36.1"
+# The version egui 0.36.1 depends on: the `TreeUpdate` the adapter is handed
+# comes straight out of egui, so the types have to be the same ones.
+accesskit = "0.24.1"
+# The newest consumer that works against accesskit 0.24.1 — the pair
+# `accesskit_macos` uses.
+accesskit_consumer = "0.38.0"
 eframe = "0.36.1"
 # `wgpu` and `snapshot` are intentionally left off: the tests run headless.
 egui_kittest = { version = "0.36.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ typed-builder = "0.23.2"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 wasm-bindgen = "0.2.106"
+wasm-bindgen-test = "0.3.56"
 wasm-bindgen-futures = "0.4.56"
 web-sys = "0.3.83"
 trybuild = "1.0.120"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The hooks, the elements and the layout attributes are listed in [docs/ARCHITECTU
 
 ## Examples
 
-Every example but one runs in the browser in the [gallery](https://fand.github.io/react-egui/), next to its source. Start with `showcase`, a small notes app that uses most of the library at once; the rest take one idea each. `shell` is standalone: a docked panel carves up the nearest enclosing `Ui`, which is the window, so there is nothing sensible for a gallery column to do with it. Some of them also have a version written with plain egui, so you can switch between the two and compare.
+Every example but one runs in the browser in the [gallery](https://fand.github.io/react-egui/), next to its source. Start with `showcase`, a small notes app that uses most of the library at once; the rest take one idea each. `shell` is standalone: a docked panel carves up the nearest enclosing `Ui`, which is the window, so there is nothing sensible for a gallery column to do with it. Some of them also have a version written with plain egui, so you can switch between the two and compare. The gallery draws to a canvas, so a screen reader cannot read it on the web — natively it can, and the widget names are there either way (`docs/tasks/a11y/`).
 
 ![The gallery: example list, the running example, and its source next to it](docs/gallery.png)
 

--- a/crates/accesskit-web/Cargo.toml
+++ b/crates/accesskit-web/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "accesskit-web"
+description = "AccessKit UI accessibility infrastructure: web adapter (prototype)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+# A prototype meant for upstream, not for crates.io.
+publish = false
+
+[lib]
+name = "accesskit_web"
+path = "src/lib.rs"
+
+[dependencies]
+accesskit.workspace = true
+accesskit_consumer.workspace = true
+wasm-bindgen.workspace = true
+web-sys = { workspace = true, features = [
+    "Document",
+    "Element",
+    "HtmlElement",
+    "Node",
+    "Window",
+] }

--- a/crates/accesskit-web/Cargo.toml
+++ b/crates/accesskit-web/Cargo.toml
@@ -20,7 +20,16 @@ wasm-bindgen.workspace = true
 web-sys = { workspace = true, features = [
     "Document",
     "Element",
+    "Event",
+    "EventTarget",
     "HtmlElement",
+    "HtmlInputElement",
+    "KeyboardEvent",
     "Node",
     "Window",
 ] }
+
+# The DOM tests need a browser. `cargo test --workspace` builds this file to
+# nothing, because it is `#![cfg(target_arch = "wasm32")]`.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/crates/accesskit-web/src/action.rs
+++ b/crates/accesskit-web/src/action.rs
@@ -1,0 +1,200 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+//! The way back: DOM events turned into `ActionRequest`s.
+//!
+//! The upstream prototype had none of this — it stored an `ActionHandler` and
+//! never called it. The handler is not something the adapter implements; it is
+//! the hole the adapter pushes requests out through.
+//!
+//! **Where the events come from.** The mirror is `pointer-events: none`, so a
+//! human clicking the page hits the canvas, and egui handles that itself. A
+//! `click` that lands on a mirror element can therefore only have been
+//! synthesised, by a screen reader activating the element it is on. That is
+//! what makes the double-fire problem Flutter solves with a 200 ms debouncer
+//! (`ClickDebouncer`, flutter#130162) not arise here — until some element is
+//! given `pointer-events: auto`, at which point it will.
+
+use accesskit::{Action, ActionData, ActionHandler, ActionRequest, NodeId, TreeId, Uuid};
+use accesskit_consumer::Node;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen::prelude::Closure;
+use web_sys::{Element, Event, HtmlElement, KeyboardEvent};
+
+/// The node an event landed on, written on the element itself so that one set
+/// of listeners on the host can serve the whole mirror.
+const NODE_ATTRIBUTE: &str = "data-accesskit-node";
+const TREE_ATTRIBUTE: &str = "data-accesskit-tree";
+
+/// Roles that are activated by Enter or Space when they have keyboard focus.
+///
+/// A real `<button>` gets this from the browser; a `<div role="button">` has
+/// to do it itself.
+const KEY_ACTIVATED_ROLES: &[&str] = &[
+    "button",
+    "checkbox",
+    "link",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "option",
+    "radio",
+    "switch",
+    "tab",
+    "treeitem",
+];
+
+/// Roles whose value is a number the client can set outright.
+const NUMERIC_ROLES: &[&str] = &["slider", "spinbutton"];
+
+/// The shared way out of the adapter. The listeners outlive any one call into
+/// the adapter, so the handler cannot simply be borrowed from it.
+pub(crate) type SharedActionHandler = Rc<RefCell<Box<dyn ActionHandler>>>;
+
+/// Say which node an element stands for, so an event can be traced back.
+pub(crate) fn tag_element(element: &HtmlElement, node: &Node<'_>) {
+    let (node_id, tree_id) = node.locate();
+    let _ = element.set_attribute(NODE_ATTRIBUTE, &node_id.0.to_string());
+    let _ = element.set_attribute(TREE_ATTRIBUTE, &tree_id.0.as_u128().to_string());
+}
+
+/// Listen once, on the host, for everything the mirror can produce.
+///
+/// The returned closures own the Rust side of each listener and must be kept
+/// alive for as long as the host is in the document.
+pub(crate) fn listen(
+    host: &HtmlElement,
+    handler: &SharedActionHandler,
+) -> Vec<Closure<dyn FnMut(Event)>> {
+    [
+        ("click", on_click as fn(&Event, &SharedActionHandler)),
+        ("keydown", on_keydown),
+        ("input", on_value_changed),
+        ("change", on_value_changed),
+        // `focus` does not bubble, so it cannot be delegated; `focusin` is the
+        // same event that does.
+        ("focusin", on_focus),
+    ]
+    .into_iter()
+    .filter_map(|(name, callback)| {
+        let handler = Rc::clone(handler);
+        let closure =
+            Closure::<dyn FnMut(Event)>::new(move |event: Event| callback(&event, &handler));
+        host.add_event_listener_with_callback(name, closure.as_ref().unchecked_ref())
+            .ok()?;
+        Some(closure)
+    })
+    .collect()
+}
+
+/// A screen reader activated an element: the same thing as a click on the
+/// widget underneath.
+fn on_click(event: &Event, handler: &SharedActionHandler) {
+    let Some(element) = target_element(event) else {
+        return;
+    };
+    send(handler, &element, Action::Click, None);
+}
+
+/// Enter and Space on a control that the browser does not activate for us.
+fn on_keydown(event: &Event, handler: &SharedActionHandler) {
+    let Some(event) = event.dyn_ref::<KeyboardEvent>() else {
+        return;
+    };
+    let key = event.key();
+    if key != "Enter" && key != " " {
+        return;
+    }
+    let Some(element) = target_element(event) else {
+        return;
+    };
+    if !role_is(&element, KEY_ACTIVATED_ROLES) {
+        return;
+    }
+    // Space would otherwise scroll the page.
+    event.prevent_default();
+    send(handler, &element, Action::Click, None);
+}
+
+/// A real form control changed. The mirror is `<div>`s today, so this fires
+/// only for the elements that will become `<input>`s (a range slider, a text
+/// box); a `<div role="slider">` has no value to change.
+fn on_value_changed(event: &Event, handler: &SharedActionHandler) {
+    let Some(element) = target_element(event) else {
+        return;
+    };
+    if !role_is(&element, NUMERIC_ROLES) {
+        return;
+    }
+    let Some(value) = element
+        .dyn_ref::<web_sys::HtmlInputElement>()
+        .and_then(|input| input.value().parse::<f64>().ok())
+    else {
+        return;
+    };
+    send(
+        handler,
+        &element,
+        Action::SetValue,
+        Some(ActionData::NumericValue(value)),
+    );
+}
+
+/// The browser moved focus into the mirror. Nothing here ever calls `focus()`,
+/// so this is never an echo of the app's own focus (which is the loop Flutter
+/// guards against with `_lastEvent == requestedFocus`).
+fn on_focus(event: &Event, handler: &SharedActionHandler) {
+    let Some(element) = target_element(event) else {
+        return;
+    };
+    send(handler, &element, Action::Focus, None);
+}
+
+/// The innermost mirrored element the event passed through.
+fn target_element(event: &Event) -> Option<Element> {
+    let mut element = event.target()?.dyn_into::<Element>().ok()?;
+    loop {
+        if element.has_attribute(NODE_ATTRIBUTE) {
+            return Some(element);
+        }
+        element = element.parent_element()?;
+    }
+}
+
+fn role_is(element: &Element, roles: &[&str]) -> bool {
+    element
+        .get_attribute("role")
+        .is_some_and(|role| roles.contains(&role.as_str()))
+}
+
+fn send(
+    handler: &SharedActionHandler,
+    element: &Element,
+    action: Action,
+    data: Option<ActionData>,
+) {
+    let Some(target_node) = element
+        .get_attribute(NODE_ATTRIBUTE)
+        .and_then(|id| id.parse::<u64>().ok())
+        .map(NodeId)
+    else {
+        return;
+    };
+    let Some(target_tree) = element
+        .get_attribute(TREE_ATTRIBUTE)
+        .and_then(|id| id.parse::<u128>().ok())
+        .map(|id| TreeId(Uuid::from_u128(id)))
+    else {
+        return;
+    };
+    handler.borrow_mut().do_action(ActionRequest {
+        action,
+        target_tree,
+        target_node,
+        data,
+    });
+}

--- a/crates/accesskit-web/src/adapter.rs
+++ b/crates/accesskit-web/src/adapter.rs
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use wasm_bindgen::JsCast as _;
 use wasm_bindgen::prelude::Closure;
 use web_sys::{Document, Element, Event, HtmlElement};
@@ -66,6 +67,16 @@ pub struct Adapter {
     state: State,
     viewport: Viewport,
     debug: bool,
+    /// The element that keeps the browser's focus — the canvas. The mirror
+    /// never takes focus itself; instead this element's
+    /// `aria-activedescendant` says which mirrored node the app has focused.
+    focus_owner: Element,
+    /// What every element of this mirror's ids start with. Unique per
+    /// adapter, so two mirrors on one page cannot collide.
+    prefix: String,
+    /// The node `aria-activedescendant` currently names, so that setting it
+    /// to the same node again can be dropped.
+    active_descendant: Option<NodeId>,
     action_handler: SharedActionHandler,
     /// The Rust side of the host's event listeners. Dropping these unhooks
     /// them, so they live exactly as long as the adapter.
@@ -77,11 +88,13 @@ impl Adapter {
     /// sits in, so that the mirror shares the canvas's containing block.
     pub fn new(
         parent: &Element,
+        focus_owner: &Element,
         mut activation_handler: impl ActivationHandler,
         action_handler: impl 'static + ActionHandler,
     ) -> Option<Self> {
         let document = web_sys::window()?.document()?;
         let viewport = Viewport::default();
+        let prefix = next_prefix();
         let action_handler: SharedActionHandler = Rc::new(RefCell::new(
             Box::new(action_handler) as Box<dyn ActionHandler>
         ));
@@ -90,7 +103,15 @@ impl Adapter {
         let state = match activation_handler.request_initial_tree() {
             Some(initial_state) => {
                 let tree = Box::new(Tree::new(initial_state, true));
-                let (host, elements) = add_initial_tree(&document, parent, &tree, viewport, false);
+                let (host, elements) = add_initial_tree(
+                    &document,
+                    parent,
+                    focus_owner,
+                    &prefix,
+                    &tree,
+                    viewport,
+                    false,
+                );
                 listeners = action::listen(&host, &action_handler);
                 State::Active {
                     tree,
@@ -109,6 +130,9 @@ impl Adapter {
             state,
             viewport,
             debug: false,
+            focus_owner: focus_owner.clone(),
+            prefix,
+            active_descendant: None,
             action_handler,
             _listeners: listeners,
         })
@@ -117,24 +141,44 @@ impl Adapter {
     /// Take one frame's `TreeUpdate`. Never call this for a discarded pass:
     /// the layout it describes is not the one that will be drawn.
     pub fn update_if_active(&mut self, update_factory: impl FnOnce() -> TreeUpdate) {
-        let debug = self.debug;
-        match &mut self.state {
+        let Self {
+            state,
+            viewport,
+            debug,
+            focus_owner,
+            prefix,
+            active_descendant,
+            action_handler,
+            _listeners,
+        } = self;
+        let debug = *debug;
+        match state {
             State::Pending {
                 is_host_focused,
                 document,
                 parent,
             } => {
                 let tree = Box::new(Tree::new(update_factory(), *is_host_focused));
-                let (host, elements) =
-                    add_initial_tree(document, parent, &tree, self.viewport, debug);
-                let listeners = action::listen(&host, &self.action_handler);
-                self.state = State::Active {
+                let (host, elements) = add_initial_tree(
+                    document,
+                    parent,
+                    focus_owner,
+                    prefix,
+                    &tree,
+                    *viewport,
+                    debug,
+                );
+                *_listeners = action::listen(&host, action_handler);
+                let focused = tree.state().focus_id();
+                *state = State::Active {
                     tree,
                     document: document.clone(),
                     host,
                     elements,
                 };
-                self._listeners = listeners;
+                if let State::Active { elements, .. } = state {
+                    settle_focus(focus_owner, active_descendant, prefix, elements, focused);
+                }
             }
             State::Active {
                 tree,
@@ -142,20 +186,40 @@ impl Adapter {
                 elements,
                 ..
             } => {
-                let mut handler = AdapterChangeHandler {
-                    document,
-                    elements,
-                    debug,
+                let moved_to = {
+                    let mut handler = AdapterChangeHandler {
+                        document,
+                        elements,
+                        debug,
+                        prefix,
+                        focus_moved_to: None,
+                    };
+                    tree.update_and_process_changes(update_factory(), &mut handler);
+                    handler.focus_moved_to
                 };
-                tree.update_and_process_changes(update_factory(), &mut handler);
+                settle_focus(
+                    focus_owner,
+                    active_descendant,
+                    prefix,
+                    elements,
+                    moved_to.flatten(),
+                );
             }
         }
     }
 
     /// Whether the host (the canvas) has the browser's focus.
     pub fn update_host_focus_state(&mut self, is_focused: bool) {
-        let debug = self.debug;
-        match &mut self.state {
+        let Self {
+            state,
+            debug,
+            focus_owner,
+            prefix,
+            active_descendant,
+            ..
+        } = self;
+        let debug = *debug;
+        match state {
             State::Pending {
                 is_host_focused, ..
             } => *is_host_focused = is_focused,
@@ -165,12 +229,27 @@ impl Adapter {
                 elements,
                 ..
             } => {
-                let mut handler = AdapterChangeHandler {
-                    document,
-                    elements,
-                    debug,
+                let moved_to = {
+                    let mut handler = AdapterChangeHandler {
+                        document,
+                        elements,
+                        debug,
+                        prefix,
+                        focus_moved_to: None,
+                    };
+                    tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
+                    handler.focus_moved_to
                 };
-                tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
+                // Losing focus reports a move to nothing, and `settle_focus`
+                // leaves the attribute where it was; regaining it reports the
+                // node again and writes the same value back.
+                settle_focus(
+                    focus_owner,
+                    active_descendant,
+                    prefix,
+                    elements,
+                    moved_to.flatten(),
+                );
             }
         }
     }
@@ -231,6 +310,73 @@ impl Adapter {
 /// the one thing the mirror must not do. `filter: opacity(0%)` is stronger
 /// than the `opacity` property, which some elements ignore. Both notes are
 /// Flutter's, from the same CSS.
+/// Ids are handed out per adapter, not per page, so that a document with two
+/// mirrors in it (a test file, say) keeps them apart.
+fn next_prefix() -> String {
+    static NEXT: AtomicU32 = AtomicU32::new(0);
+    format!("accesskit-mirror-{}", NEXT.fetch_add(1, Ordering::Relaxed))
+}
+
+/// The id of the element standing for a node, which is what
+/// `aria-activedescendant` names.
+fn element_id(prefix: &str, id: NodeId) -> String {
+    format!("{prefix}-{}", u128::from(id))
+}
+
+/// Point the focus owner at the mirror.
+///
+/// `aria-activedescendant` may only name an element the referencing element
+/// owns — a DOM descendant, or one named by `aria-owns` (ARIA 1.2, and the
+/// APG's "Developing a Keyboard Interface"). The host is the canvas's
+/// *sibling*, so `aria-owns` is what makes the reference legal. The attribute
+/// is also only allowed on a few roles, none of which a bare `<canvas>` has,
+/// so the canvas is given `role="application"` — the one that fits a widget
+/// tree drawn by the app, and the one that puts a screen reader in the mode
+/// where `aria-activedescendant` means anything.
+fn own_the_mirror(focus_owner: &Element, host_id: &str) {
+    if !focus_owner.has_attribute("role") {
+        let _ = focus_owner.set_attribute("role", "application");
+    }
+    let _ = focus_owner.set_attribute("aria-owns", host_id);
+}
+
+/// Say which node the app has focused, after the DOM it names is in place.
+///
+/// Three rules, all Flutter's, from a semantics layer that had to learn them
+/// (plan.md 1.4):
+///
+/// (a) apply the focus only once the tree update is fully applied — hence
+///     this runs after `update_and_process_changes` returns, not inside
+///     `focus_moved`;
+/// (b) never take focus away. `blur()` is the mistake Flutter warns about;
+///     here its equivalent is clearing `aria-activedescendant` when the app
+///     reports no focus, so that is exactly what is not done. The canvas
+///     losing the browser's focus is not the app forgetting where it was;
+/// (c) drop a repeat of the node already named.
+fn settle_focus(
+    focus_owner: &Element,
+    active_descendant: &mut Option<NodeId>,
+    prefix: &str,
+    elements: &HashMap<NodeId, HtmlElement>,
+    moved_to: Option<NodeId>,
+) {
+    if let Some(new_focus) = moved_to
+        && *active_descendant != Some(new_focus)
+        && elements.contains_key(&new_focus)
+    {
+        *active_descendant = Some(new_focus);
+        let _ = focus_owner.set_attribute("aria-activedescendant", &element_id(prefix, new_focus));
+    }
+    // A reference to an element that has left the document is worse than
+    // none: this is the one case where the attribute does come off.
+    if let Some(current) = *active_descendant
+        && !elements.contains_key(&current)
+    {
+        *active_descendant = None;
+        let _ = focus_owner.remove_attribute("aria-activedescendant");
+    }
+}
+
 fn set_host_style(host: &HtmlElement, viewport: Viewport, debug: bool) {
     let scale = if viewport.pixels_per_point > 0.0 {
         1.0 / viewport.pixels_per_point
@@ -253,16 +399,25 @@ fn set_host_style(host: &HtmlElement, viewport: Viewport, debug: bool) {
 fn add_initial_tree(
     document: &Document,
     parent: &Element,
+    focus_owner: &Element,
+    prefix: &str,
     tree: &Tree,
     viewport: Viewport,
     debug: bool,
 ) -> (HtmlElement, HashMap<NodeId, HtmlElement>) {
     let host = create_element(document, ElementKind::Div);
+    let host_id = format!("{prefix}-host");
+    host.set_id(&host_id);
+    // The mirror is never a tab stop: the canvas is the one place the
+    // browser's focus is allowed to be, because eframe reads anything else as
+    // "the app lost focus" and stops taking keys (plan.md 1.3).
+    let _ = host.set_attribute("tabindex", "-1");
     set_host_style(&host, viewport, debug);
     let _ = parent.append_child(&host);
+    own_the_mirror(focus_owner, &host_id);
     let mut elements = HashMap::new();
     let root_node = tree.state().root();
-    add_element_recursive(document, &host, &root_node, &mut elements, debug);
+    add_element_recursive(document, &host, prefix, &root_node, &mut elements, debug);
     (host, elements)
 }
 
@@ -278,12 +433,15 @@ fn create_element(document: &Document, kind: ElementKind) -> HtmlElement {
 fn add_element(
     document: &Document,
     parent: &HtmlElement,
+    prefix: &str,
     node: &Node<'_>,
     elements: &mut HashMap<NodeId, HtmlElement>,
     debug: bool,
 ) -> HtmlElement {
     let wrapper = NodeWrapper { node: *node, debug };
     let element = create_element(document, wrapper.element_kind());
+    // `aria-activedescendant` names an element by id, so every node needs one.
+    element.set_id(&element_id(prefix, node.id()));
     wrapper.set_all_attributes(&element);
     action::tag_element(&element, node);
     let _ = parent.append_child(&element);
@@ -294,13 +452,14 @@ fn add_element(
 fn add_element_recursive(
     document: &Document,
     parent: &HtmlElement,
+    prefix: &str,
     node: &Node<'_>,
     elements: &mut HashMap<NodeId, HtmlElement>,
     debug: bool,
 ) {
-    let element = add_element(document, parent, node, elements, debug);
+    let element = add_element(document, parent, prefix, node, elements, debug);
     for child in node.filtered_children(&filter) {
-        add_element_recursive(document, &element, &child, elements, debug);
+        add_element_recursive(document, &element, prefix, &child, elements, debug);
     }
 }
 
@@ -308,6 +467,10 @@ struct AdapterChangeHandler<'a> {
     document: &'a Document,
     elements: &'a mut HashMap<NodeId, HtmlElement>,
     debug: bool,
+    prefix: &'a str,
+    /// Where focus went, recorded rather than applied: the outer `Option` is
+    /// "was there a move at all", the inner one is the node it went to.
+    focus_moved_to: Option<Option<NodeId>>,
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
@@ -327,6 +490,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         add_element(
             self.document,
             &parent_element,
+            self.prefix,
             node,
             self.elements,
             self.debug,
@@ -354,6 +518,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         // being rebuilt, so every other entry in the map stays valid.
         if old_wrapper.element_kind() != new_wrapper.element_kind() {
             let replacement = create_element(self.document, new_wrapper.element_kind());
+            replacement.set_id(&element_id(self.prefix, new_node.id()));
             while let Some(child) = element.first_child() {
                 let _ = replacement.append_child(&child);
             }
@@ -366,13 +531,14 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         new_wrapper.update_attributes(element, &old_wrapper);
     }
 
-    fn focus_moved(&mut self, _old_node: Option<&Node<'_>>, _new_node: Option<&Node<'_>>) {
-        // Moving the browser's focus onto a mirror element is the one thing
-        // that is known not to work yet: eframe treats "the canvas is not the
-        // active element" as "the app lost focus" and stops taking keys
-        // (plan.md 1.3). The upstream prototype called `element.focus()` here,
-        // and `blur()` on the way out, which Flutter's semantics layer warns
-        // against. Both are left out until the focus design is settled.
+    fn focus_moved(&mut self, _old_node: Option<&Node<'_>>, new_node: Option<&Node<'_>>) {
+        // Nothing here calls `element.focus()`. Real DOM focus stays on the
+        // canvas, because eframe reads "the canvas is not the active element"
+        // as "the app lost focus" and stops taking keys (plan.md 1.3); the
+        // canvas's `aria-activedescendant` says where the app's focus is
+        // instead. Only record it: the elements it may name are not all built
+        // yet at this point in the update.
+        self.focus_moved_to = Some(new_node.map(|node| node.id()));
     }
 
     fn node_removed(&mut self, node: &Node<'_>) {

--- a/crates/accesskit-web/src/adapter.rs
+++ b/crates/accesskit-web/src/adapter.rs
@@ -6,10 +6,30 @@
 use accesskit::{ActionHandler, ActivationHandler, TreeUpdate};
 use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler};
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use wasm_bindgen::JsCast as _;
 use web_sys::{Document, Element, HtmlElement};
 
 use crate::{filters::filter, node::NodeWrapper};
+
+/// Where the mirror sits over the canvas, and at what scale.
+#[derive(Clone, Copy, Debug)]
+struct Viewport {
+    /// The canvas's top-left corner, in CSS pixels, in the coordinates of the
+    /// containing block the mirror host shares with it.
+    offset: (f64, f64),
+    /// Physical pixels per CSS pixel, as the tree's coordinates use them.
+    pixels_per_point: f64,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self {
+            offset: (0.0, 0.0),
+            pixels_per_point: 1.0,
+        }
+    }
+}
 
 /// Before the first tree arrives there is nothing to mirror, so the adapter
 /// only remembers where the mirror will go.
@@ -23,7 +43,6 @@ enum State {
         // Boxed: `Tree` is several hundred bytes and `Pending` is three words.
         tree: Box<Tree>,
         document: Document,
-        #[expect(dead_code, reason = "read once the mirror is positioned")]
         host: HtmlElement,
         elements: HashMap<NodeId, HtmlElement>,
     },
@@ -32,9 +51,16 @@ enum State {
 /// A DOM mirror of an AccessKit tree.
 ///
 /// One `<div>` per accessibility node, nested the way the tree is, under a
-/// single host element the adapter appends to `parent`.
+/// single host element the adapter appends to `parent`. Every node is placed
+/// at its own bounding box, so a magnifier or a braille display can route to
+/// the pixels the widget is actually drawn on.
+///
+/// The mirror is invisible and does not take the mouse: the canvas underneath
+/// keeps drawing and keeps getting the pointer events.
 pub struct Adapter {
     state: State,
+    viewport: Viewport,
+    debug: bool,
     #[expect(dead_code, reason = "wired up in the DOM -> ActionRequest step")]
     action_handler: Box<dyn ActionHandler>,
 }
@@ -48,11 +74,12 @@ impl Adapter {
         action_handler: impl 'static + ActionHandler,
     ) -> Option<Self> {
         let document = web_sys::window()?.document()?;
+        let viewport = Viewport::default();
 
         let state = match activation_handler.request_initial_tree() {
             Some(initial_state) => {
                 let tree = Box::new(Tree::new(initial_state, true));
-                let (host, elements) = add_initial_tree(&document, parent, &tree);
+                let (host, elements) = add_initial_tree(&document, parent, &tree, viewport, false);
                 State::Active {
                     tree,
                     document,
@@ -68,6 +95,8 @@ impl Adapter {
         };
         Some(Self {
             state,
+            viewport,
+            debug: false,
             action_handler: Box::new(action_handler),
         })
     }
@@ -75,6 +104,7 @@ impl Adapter {
     /// Take one frame's `TreeUpdate`. Never call this for a discarded pass:
     /// the layout it describes is not the one that will be drawn.
     pub fn update_if_active(&mut self, update_factory: impl FnOnce() -> TreeUpdate) {
+        let debug = self.debug;
         match &mut self.state {
             State::Pending {
                 is_host_focused,
@@ -82,7 +112,8 @@ impl Adapter {
                 parent,
             } => {
                 let tree = Box::new(Tree::new(update_factory(), *is_host_focused));
-                let (host, elements) = add_initial_tree(document, parent, &tree);
+                let (host, elements) =
+                    add_initial_tree(document, parent, &tree, self.viewport, debug);
                 self.state = State::Active {
                     tree,
                     document: document.clone(),
@@ -96,7 +127,11 @@ impl Adapter {
                 elements,
                 ..
             } => {
-                let mut handler = AdapterChangeHandler { document, elements };
+                let mut handler = AdapterChangeHandler {
+                    document,
+                    elements,
+                    debug,
+                };
                 tree.update_and_process_changes(update_factory(), &mut handler);
             }
         }
@@ -104,6 +139,7 @@ impl Adapter {
 
     /// Whether the host (the canvas) has the browser's focus.
     pub fn update_host_focus_state(&mut self, is_focused: bool) {
+        let debug = self.debug;
         match &mut self.state {
             State::Pending {
                 is_host_focused, ..
@@ -114,23 +150,104 @@ impl Adapter {
                 elements,
                 ..
             } => {
-                let mut handler = AdapterChangeHandler { document, elements };
+                let mut handler = AdapterChangeHandler {
+                    document,
+                    elements,
+                    debug,
+                };
                 tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
             }
         }
     }
+
+    /// Line the mirror up with the canvas.
+    ///
+    /// `offset` is the canvas's top-left corner in CSS pixels;
+    /// `pixels_per_point` is what the tree's coordinates are in. The whole
+    /// mirror is scaled by its reciprocal once, on the host, rather than every
+    /// node dividing its own box — the same trick `<flt-semantics-host>` uses.
+    pub fn set_viewport(&mut self, offset: (f64, f64), pixels_per_point: f64) {
+        let viewport = Viewport {
+            offset,
+            pixels_per_point,
+        };
+        if self.viewport.offset == viewport.offset
+            && self.viewport.pixels_per_point == viewport.pixels_per_point
+        {
+            return;
+        }
+        self.viewport = viewport;
+        if let State::Active { host, .. } = &self.state {
+            set_host_style(host, viewport, self.debug);
+        }
+    }
+
+    /// Show the mirror: no transparency, and a green outline around every node.
+    ///
+    /// For looking at the mirror in devtools. An outline rather than a border,
+    /// because a border would move the boxes it is drawn on.
+    pub fn set_debug(&mut self, debug: bool) {
+        if self.debug == debug {
+            return;
+        }
+        self.debug = debug;
+        if let State::Active {
+            tree,
+            host,
+            elements,
+            ..
+        } = &self.state
+        {
+            set_host_style(host, self.viewport, debug);
+            for (id, element) in elements {
+                if let Some(node) = tree.state().node_by_id(*id) {
+                    NodeWrapper { node, debug }.set_style(element);
+                }
+            }
+        }
+    }
+}
+
+/// The mirror host: transparent, out of the way of the mouse, and scaled from
+/// the tree's physical pixels back to CSS pixels.
+///
+/// Being invisible is not the same as being hidden: `visibility: hidden` and
+/// `display: none` take the elements out of the accessibility tree, which is
+/// the one thing the mirror must not do. `filter: opacity(0%)` is stronger
+/// than the `opacity` property, which some elements ignore. Both notes are
+/// Flutter's, from the same CSS.
+fn set_host_style(host: &HtmlElement, viewport: Viewport, debug: bool) {
+    let scale = if viewport.pixels_per_point > 0.0 {
+        1.0 / viewport.pixels_per_point
+    } else {
+        1.0
+    };
+    let mut style = String::new();
+    let _ = write!(
+        style,
+        "position:absolute;left:{}px;top:{}px;width:0;height:0;overflow:visible;\
+         transform-origin:0 0;transform:scale({scale});pointer-events:none;",
+        viewport.offset.0, viewport.offset.1
+    );
+    if !debug {
+        style.push_str("filter:opacity(0%);color:rgba(0,0,0,0);");
+    }
+    let _ = host.set_attribute("style", &style);
 }
 
 fn add_initial_tree(
     document: &Document,
     parent: &Element,
     tree: &Tree,
+    viewport: Viewport,
+    debug: bool,
 ) -> (HtmlElement, HashMap<NodeId, HtmlElement>) {
     let host = create_element(document);
+    set_host_style(&host, viewport, debug);
     let _ = parent.append_child(&host);
     let mut elements = HashMap::new();
     let root_node = tree.state().root();
-    add_element_recursive(document, &host, &root_node, &mut elements);
+    add_element_recursive(document, &host, &root_node, &mut elements, debug);
     (host, elements)
 }
 
@@ -146,10 +263,10 @@ fn add_element(
     parent: &HtmlElement,
     node: &Node<'_>,
     elements: &mut HashMap<NodeId, HtmlElement>,
+    debug: bool,
 ) -> HtmlElement {
     let element = create_element(document);
-    let wrapper = NodeWrapper(*node);
-    wrapper.set_all_attributes(&element);
+    NodeWrapper { node: *node, debug }.set_all_attributes(&element);
     let _ = parent.append_child(&element);
     elements.insert(node.id(), element.clone());
     element
@@ -160,16 +277,18 @@ fn add_element_recursive(
     parent: &HtmlElement,
     node: &Node<'_>,
     elements: &mut HashMap<NodeId, HtmlElement>,
+    debug: bool,
 ) {
-    let element = add_element(document, parent, node, elements);
+    let element = add_element(document, parent, node, elements, debug);
     for child in node.filtered_children(&filter) {
-        add_element_recursive(document, &element, &child, elements);
+        add_element_recursive(document, &element, &child, elements, debug);
     }
 }
 
 struct AdapterChangeHandler<'a> {
     document: &'a Document,
     elements: &'a mut HashMap<NodeId, HtmlElement>,
+    debug: bool,
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
@@ -186,7 +305,13 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         let Some(parent_element) = self.elements.get(&parent.id()).cloned() else {
             return;
         };
-        add_element(self.document, &parent_element, node, self.elements);
+        add_element(
+            self.document,
+            &parent_element,
+            node,
+            self.elements,
+            self.debug,
+        );
     }
 
     fn node_updated(&mut self, old_node: &Node<'_>, new_node: &Node<'_>) {
@@ -196,8 +321,15 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         let Some(element) = self.elements.get(&new_node.id()) else {
             return;
         };
-        let old_wrapper = NodeWrapper(*old_node);
-        let new_wrapper = NodeWrapper(*new_node);
+        let debug = self.debug;
+        let old_wrapper = NodeWrapper {
+            node: *old_node,
+            debug,
+        };
+        let new_wrapper = NodeWrapper {
+            node: *new_node,
+            debug,
+        };
         new_wrapper.update_attributes(element, &old_wrapper);
     }
 

--- a/crates/accesskit-web/src/adapter.rs
+++ b/crates/accesskit-web/src/adapter.rs
@@ -14,6 +14,7 @@ use wasm_bindgen::prelude::Closure;
 use web_sys::{Document, Element, Event, HtmlElement};
 
 use crate::action::{self, SharedActionHandler};
+use crate::node::ElementKind;
 use crate::{filters::filter, node::NodeWrapper};
 
 /// Where the mirror sits over the canvas, and at what scale.
@@ -256,7 +257,7 @@ fn add_initial_tree(
     viewport: Viewport,
     debug: bool,
 ) -> (HtmlElement, HashMap<NodeId, HtmlElement>) {
-    let host = create_element(document);
+    let host = create_element(document, ElementKind::Div);
     set_host_style(&host, viewport, debug);
     let _ = parent.append_child(&host);
     let mut elements = HashMap::new();
@@ -265,11 +266,13 @@ fn add_initial_tree(
     (host, elements)
 }
 
-fn create_element(document: &Document) -> HtmlElement {
-    document
-        .create_element("div")
-        .expect("a document can always make a <div>")
-        .unchecked_into::<HtmlElement>()
+fn create_element(document: &Document, kind: ElementKind) -> HtmlElement {
+    let element = document
+        .create_element(kind.tag_name())
+        .expect("a document can always make a <div> or an <input>")
+        .unchecked_into::<HtmlElement>();
+    kind.init(&element);
+    element
 }
 
 fn add_element(
@@ -279,8 +282,9 @@ fn add_element(
     elements: &mut HashMap<NodeId, HtmlElement>,
     debug: bool,
 ) -> HtmlElement {
-    let element = create_element(document);
-    NodeWrapper { node: *node, debug }.set_all_attributes(&element);
+    let wrapper = NodeWrapper { node: *node, debug };
+    let element = create_element(document, wrapper.element_kind());
+    wrapper.set_all_attributes(&element);
     action::tag_element(&element, node);
     let _ = parent.append_child(&element);
     elements.insert(node.id(), element.clone());
@@ -345,6 +349,20 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
             node: *new_node,
             debug,
         };
+        // A `<div>` cannot become an `<input>`, so a node whose role crossed
+        // that line needs a new element. Its children move over rather than
+        // being rebuilt, so every other entry in the map stays valid.
+        if old_wrapper.element_kind() != new_wrapper.element_kind() {
+            let replacement = create_element(self.document, new_wrapper.element_kind());
+            while let Some(child) = element.first_child() {
+                let _ = replacement.append_child(&child);
+            }
+            new_wrapper.set_all_attributes(&replacement);
+            action::tag_element(&replacement, new_node);
+            let _ = element.replace_with_with_node_1(&replacement);
+            self.elements.insert(new_node.id(), replacement);
+            return;
+        }
         new_wrapper.update_attributes(element, &old_wrapper);
     }
 

--- a/crates/accesskit-web/src/adapter.rs
+++ b/crates/accesskit-web/src/adapter.rs
@@ -1,0 +1,218 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit::{ActionHandler, ActivationHandler, TreeUpdate};
+use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler};
+use std::collections::HashMap;
+use wasm_bindgen::JsCast as _;
+use web_sys::{Document, Element, HtmlElement};
+
+use crate::{filters::filter, node::NodeWrapper};
+
+/// Before the first tree arrives there is nothing to mirror, so the adapter
+/// only remembers where the mirror will go.
+enum State {
+    Pending {
+        is_host_focused: bool,
+        document: Document,
+        parent: Element,
+    },
+    Active {
+        // Boxed: `Tree` is several hundred bytes and `Pending` is three words.
+        tree: Box<Tree>,
+        document: Document,
+        #[expect(dead_code, reason = "read once the mirror is positioned")]
+        host: HtmlElement,
+        elements: HashMap<NodeId, HtmlElement>,
+    },
+}
+
+/// A DOM mirror of an AccessKit tree.
+///
+/// One `<div>` per accessibility node, nested the way the tree is, under a
+/// single host element the adapter appends to `parent`.
+pub struct Adapter {
+    state: State,
+    #[expect(dead_code, reason = "wired up in the DOM -> ActionRequest step")]
+    action_handler: Box<dyn ActionHandler>,
+}
+
+impl Adapter {
+    /// Build the mirror under `parent`, which should be the element the canvas
+    /// sits in, so that the mirror shares the canvas's containing block.
+    pub fn new(
+        parent: &Element,
+        mut activation_handler: impl ActivationHandler,
+        action_handler: impl 'static + ActionHandler,
+    ) -> Option<Self> {
+        let document = web_sys::window()?.document()?;
+
+        let state = match activation_handler.request_initial_tree() {
+            Some(initial_state) => {
+                let tree = Box::new(Tree::new(initial_state, true));
+                let (host, elements) = add_initial_tree(&document, parent, &tree);
+                State::Active {
+                    tree,
+                    document,
+                    host,
+                    elements,
+                }
+            }
+            None => State::Pending {
+                is_host_focused: true,
+                document,
+                parent: parent.clone(),
+            },
+        };
+        Some(Self {
+            state,
+            action_handler: Box::new(action_handler),
+        })
+    }
+
+    /// Take one frame's `TreeUpdate`. Never call this for a discarded pass:
+    /// the layout it describes is not the one that will be drawn.
+    pub fn update_if_active(&mut self, update_factory: impl FnOnce() -> TreeUpdate) {
+        match &mut self.state {
+            State::Pending {
+                is_host_focused,
+                document,
+                parent,
+            } => {
+                let tree = Box::new(Tree::new(update_factory(), *is_host_focused));
+                let (host, elements) = add_initial_tree(document, parent, &tree);
+                self.state = State::Active {
+                    tree,
+                    document: document.clone(),
+                    host,
+                    elements,
+                };
+            }
+            State::Active {
+                tree,
+                document,
+                elements,
+                ..
+            } => {
+                let mut handler = AdapterChangeHandler { document, elements };
+                tree.update_and_process_changes(update_factory(), &mut handler);
+            }
+        }
+    }
+
+    /// Whether the host (the canvas) has the browser's focus.
+    pub fn update_host_focus_state(&mut self, is_focused: bool) {
+        match &mut self.state {
+            State::Pending {
+                is_host_focused, ..
+            } => *is_host_focused = is_focused,
+            State::Active {
+                tree,
+                document,
+                elements,
+                ..
+            } => {
+                let mut handler = AdapterChangeHandler { document, elements };
+                tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
+            }
+        }
+    }
+}
+
+fn add_initial_tree(
+    document: &Document,
+    parent: &Element,
+    tree: &Tree,
+) -> (HtmlElement, HashMap<NodeId, HtmlElement>) {
+    let host = create_element(document);
+    let _ = parent.append_child(&host);
+    let mut elements = HashMap::new();
+    let root_node = tree.state().root();
+    add_element_recursive(document, &host, &root_node, &mut elements);
+    (host, elements)
+}
+
+fn create_element(document: &Document) -> HtmlElement {
+    document
+        .create_element("div")
+        .expect("a document can always make a <div>")
+        .unchecked_into::<HtmlElement>()
+}
+
+fn add_element(
+    document: &Document,
+    parent: &HtmlElement,
+    node: &Node<'_>,
+    elements: &mut HashMap<NodeId, HtmlElement>,
+) -> HtmlElement {
+    let element = create_element(document);
+    let wrapper = NodeWrapper(*node);
+    wrapper.set_all_attributes(&element);
+    let _ = parent.append_child(&element);
+    elements.insert(node.id(), element.clone());
+    element
+}
+
+fn add_element_recursive(
+    document: &Document,
+    parent: &HtmlElement,
+    node: &Node<'_>,
+    elements: &mut HashMap<NodeId, HtmlElement>,
+) {
+    let element = add_element(document, parent, node, elements);
+    for child in node.filtered_children(&filter) {
+        add_element_recursive(document, &element, &child, elements);
+    }
+}
+
+struct AdapterChangeHandler<'a> {
+    document: &'a Document,
+    elements: &'a mut HashMap<NodeId, HtmlElement>,
+}
+
+impl TreeChangeHandler for AdapterChangeHandler<'_> {
+    fn node_added(&mut self, node: &Node<'_>) {
+        if filter(node) != FilterResult::Include {
+            return;
+        }
+        if self.elements.contains_key(&node.id()) {
+            return;
+        }
+        let Some(parent) = node.filtered_parent(&filter) else {
+            return;
+        };
+        let Some(parent_element) = self.elements.get(&parent.id()).cloned() else {
+            return;
+        };
+        add_element(self.document, &parent_element, node, self.elements);
+    }
+
+    fn node_updated(&mut self, old_node: &Node<'_>, new_node: &Node<'_>) {
+        if filter(new_node) != FilterResult::Include {
+            return;
+        }
+        let Some(element) = self.elements.get(&new_node.id()) else {
+            return;
+        };
+        let old_wrapper = NodeWrapper(*old_node);
+        let new_wrapper = NodeWrapper(*new_node);
+        new_wrapper.update_attributes(element, &old_wrapper);
+    }
+
+    fn focus_moved(&mut self, _old_node: Option<&Node<'_>>, _new_node: Option<&Node<'_>>) {
+        // Moving the browser's focus onto a mirror element is the one thing
+        // that is known not to work yet: eframe treats "the canvas is not the
+        // active element" as "the app lost focus" and stops taking keys
+        // (plan.md 1.3). The upstream prototype called `element.focus()` here,
+        // and `blur()` on the way out, which Flutter's semantics layer warns
+        // against. Both are left out until the focus design is settled.
+    }
+
+    fn node_removed(&mut self, node: &Node<'_>) {
+        if let Some(element) = self.elements.remove(&node.id()) {
+            element.remove();
+        }
+    }
+}

--- a/crates/accesskit-web/src/adapter.rs
+++ b/crates/accesskit-web/src/adapter.rs
@@ -5,11 +5,15 @@
 
 use accesskit::{ActionHandler, ActivationHandler, TreeUpdate};
 use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::rc::Rc;
 use wasm_bindgen::JsCast as _;
-use web_sys::{Document, Element, HtmlElement};
+use wasm_bindgen::prelude::Closure;
+use web_sys::{Document, Element, Event, HtmlElement};
 
+use crate::action::{self, SharedActionHandler};
 use crate::{filters::filter, node::NodeWrapper};
 
 /// Where the mirror sits over the canvas, and at what scale.
@@ -61,8 +65,10 @@ pub struct Adapter {
     state: State,
     viewport: Viewport,
     debug: bool,
-    #[expect(dead_code, reason = "wired up in the DOM -> ActionRequest step")]
-    action_handler: Box<dyn ActionHandler>,
+    action_handler: SharedActionHandler,
+    /// The Rust side of the host's event listeners. Dropping these unhooks
+    /// them, so they live exactly as long as the adapter.
+    _listeners: Vec<Closure<dyn FnMut(Event)>>,
 }
 
 impl Adapter {
@@ -75,11 +81,16 @@ impl Adapter {
     ) -> Option<Self> {
         let document = web_sys::window()?.document()?;
         let viewport = Viewport::default();
+        let action_handler: SharedActionHandler = Rc::new(RefCell::new(
+            Box::new(action_handler) as Box<dyn ActionHandler>
+        ));
 
+        let mut listeners = Vec::new();
         let state = match activation_handler.request_initial_tree() {
             Some(initial_state) => {
                 let tree = Box::new(Tree::new(initial_state, true));
                 let (host, elements) = add_initial_tree(&document, parent, &tree, viewport, false);
+                listeners = action::listen(&host, &action_handler);
                 State::Active {
                     tree,
                     document,
@@ -97,7 +108,8 @@ impl Adapter {
             state,
             viewport,
             debug: false,
-            action_handler: Box::new(action_handler),
+            action_handler,
+            _listeners: listeners,
         })
     }
 
@@ -114,12 +126,14 @@ impl Adapter {
                 let tree = Box::new(Tree::new(update_factory(), *is_host_focused));
                 let (host, elements) =
                     add_initial_tree(document, parent, &tree, self.viewport, debug);
+                let listeners = action::listen(&host, &self.action_handler);
                 self.state = State::Active {
                     tree,
                     document: document.clone(),
                     host,
                     elements,
                 };
+                self._listeners = listeners;
             }
             State::Active {
                 tree,
@@ -267,6 +281,7 @@ fn add_element(
 ) -> HtmlElement {
     let element = create_element(document);
     NodeWrapper { node: *node, debug }.set_all_attributes(&element);
+    action::tag_element(&element, node);
     let _ = parent.append_child(&element);
     elements.insert(node.id(), element.clone());
     element

--- a/crates/accesskit-web/src/filters.rs
+++ b/crates/accesskit-web/src/filters.rs
@@ -1,0 +1,6 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+pub(crate) use accesskit_consumer::common_filter as filter;

--- a/crates/accesskit-web/src/lib.rs
+++ b/crates/accesskit-web/src/lib.rs
@@ -25,6 +25,8 @@
 //! why. Copyright of the original code stays with the AccessKit authors and it
 //! keeps their Apache-2.0 OR MIT terms, which are also this repository's.
 
+mod action;
+
 mod adapter;
 pub use adapter::Adapter;
 

--- a/crates/accesskit-web/src/lib.rs
+++ b/crates/accesskit-web/src/lib.rs
@@ -1,0 +1,32 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+//! An AccessKit adapter for the web: a `TreeUpdate` mirrored into the DOM.
+//!
+//! The application draws into a `<canvas>`, so nothing it draws reaches
+//! assistive technology. This adapter keeps a hidden `<div>` per accessibility
+//! node next to the canvas, with the ARIA role, name and value the node
+//! carries. Flutter web and Google Docs solve the same problem the same way.
+//!
+//! Nothing here knows about egui, eframe or any toolkit: the only input is an
+//! [`accesskit::TreeUpdate`], the only output is an
+//! [`accesskit::ActionRequest`] handed back through the
+//! [`accesskit::ActionHandler`] the caller passes in.
+//!
+//! # Attribution
+//!
+//! This is a port of the unreleased `accesskit_web` prototype on AccessKit's
+//! [`web-basics`](https://github.com/AccessKit/accesskit/tree/web-basics)
+//! branch (last touched 2024-07), brought up to `accesskit` 0.24 /
+//! `accesskit_consumer` 0.38. The role table, the node wrapper and the shape of
+//! the adapter are theirs; see `docs/tasks/a11y/plan.md` for what changed and
+//! why. Copyright of the original code stays with the AccessKit authors and it
+//! keeps their Apache-2.0 OR MIT terms, which are also this repository's.
+
+mod adapter;
+pub use adapter::Adapter;
+
+mod filters;
+mod node;

--- a/crates/accesskit-web/src/node.rs
+++ b/crates/accesskit-web/src/node.rs
@@ -238,15 +238,39 @@ impl NodeWrapper<'_> {
             None => style.push_str("left:0;top:0;"),
         }
         if self.debug {
-            // An outline, not a border: a border would move the layout.
-            style.push_str("outline:1px solid green;");
+            // An outline, not a border: a border would move the layout. The
+            // focused node gets its own colour, which is what makes
+            // `?a11y-debug` show where the focus is.
+            if self.node.is_focused() {
+                style.push_str("outline:2px solid magenta;");
+            } else {
+                style.push_str("outline:1px solid green;");
+            }
         }
         Some(style)
     }
 
-    /// Focusable nodes are Tab stops, in tree order, which is DOM order.
+    /// Never a tab stop.
+    ///
+    /// The upstream prototype's `"0"` would put the browser's focus into the
+    /// mirror, and eframe reads any active element but the canvas as "the app
+    /// lost focus" (plan.md 1.3). `"-1"` keeps the element out of the tab
+    /// order while still marking which nodes are the app's own stops — egui
+    /// moves between those itself, on the Tab key the canvas forwards to it.
     fn tabindex(&self) -> Option<String> {
-        self.node.is_focusable(&filter).then(|| "0".into())
+        self.node.is_focusable(&filter).then(|| "-1".into())
+    }
+
+    /// Which node the app has focused, for `?a11y-debug` and for anyone
+    /// reading the DOM to see where the focus went.
+    ///
+    /// Not `aria-selected`: that means something specific on a handful of
+    /// roles (an option in a listbox, a row in a grid) and nothing on a
+    /// button, so writing it everywhere would be telling a screen reader
+    /// something untrue. `aria-activedescendant` on the canvas is the whole
+    /// of the claim; this is a marker.
+    fn data_focused(&self) -> Option<String> {
+        self.node.is_focused().then(|| "true".into())
     }
 
     /// A `<div>` unless the node carries a value a screen reader can set or
@@ -425,6 +449,7 @@ attributes! {
     ("tabindex", tabindex),
     ("aria-label", aria_label),
     ("aria-checked", aria_checked),
+    ("data-focused", data_focused),
     // Both the ARIA values and the real `<input>` ones: the ARIA pair is what
     // a `<div role="slider">` is read from, and it stays right for the real
     // control too, since the two are written from the same numbers.

--- a/crates/accesskit-web/src/node.rs
+++ b/crates/accesskit-web/src/node.rs
@@ -1,0 +1,251 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit::{Role, Toggled};
+use accesskit_consumer::Node;
+use web_sys::HtmlElement;
+
+use crate::filters::filter;
+
+pub(crate) struct NodeWrapper<'a>(pub(crate) Node<'a>);
+
+impl NodeWrapper<'_> {
+    fn role(&self) -> Option<String> {
+        let role = self.0.role();
+        match role {
+            Role::Cell => Some("cell".into()),
+            Role::Image => Some("img".into()),
+            Role::Link => Some("link".into()),
+            Role::Row => Some("row".into()),
+            Role::ListItem => Some("listitem".into()),
+            Role::TreeItem => Some("treeitem".into()),
+            Role::ListBoxOption => Some("option".into()),
+            Role::MenuItem | Role::MenuListOption => Some("menuitem".into()),
+            Role::Paragraph => Some("paragraph".into()),
+            Role::GenericContainer => Some("generic".into()),
+            Role::CheckBox => Some("checkbox".into()),
+            Role::RadioButton => Some("radio".into()),
+            Role::TextInput => Some("textbox".into()),
+            Role::Button | Role::DefaultButton => Some("button".into()),
+            Role::RowHeader => Some("rowheader".into()),
+            Role::ColumnHeader => Some("columnheader".into()),
+            Role::RowGroup => Some("rowgroup".into()),
+            Role::List => Some("list".into()),
+            Role::Table => Some("table".into()),
+            Role::Switch => Some("switch".into()),
+            Role::Menu => Some("menu".into()),
+            Role::MultilineTextInput => Some("textbox".into()),
+            Role::SearchInput => Some("searchbox".into()),
+            Role::DateInput
+            | Role::DateTimeInput
+            | Role::WeekInput
+            | Role::MonthInput
+            | Role::TimeInput
+            | Role::EmailInput
+            | Role::NumberInput
+            | Role::PasswordInput
+            | Role::PhoneNumberInput
+            | Role::UrlInput => Some("textbox".into()),
+            Role::Alert => Some("alert".into()),
+            Role::AlertDialog => Some("alertdialog".into()),
+            Role::Application => Some("application".into()),
+            Role::Article => Some("article".into()),
+            Role::Banner => Some("banner".into()),
+            Role::Blockquote => Some("blockquote".into()),
+            Role::Caption => Some("caption".into()),
+            Role::Code => Some("code".into()),
+            Role::ComboBox | Role::EditableComboBox => Some("combobox".into()),
+            Role::Complementary => Some("complementary".into()),
+            Role::Comment => Some("comment".into()),
+            Role::ContentDeletion => Some("deletion".into()),
+            Role::ContentInsertion => Some("insertion".into()),
+            Role::ContentInfo => Some("contentinfo".into()),
+            Role::Definition => Some("definition".into()),
+            Role::Dialog => Some("dialog".into()),
+            Role::Document => Some("document".into()),
+            Role::Emphasis => Some("emphasis".into()),
+            Role::Feed => Some("feed".into()),
+            Role::Figure => Some("figure".into()),
+            Role::Footer => Some("contentinfo".into()),
+            Role::Form => Some("form".into()),
+            Role::Grid => Some("grid".into()),
+            Role::Group => Some("group".into()),
+            Role::Header => Some("banner".into()),
+            Role::Heading => Some("heading".into()),
+            Role::ListBox => Some("listbox".into()),
+            Role::Log => Some("log".into()),
+            Role::Main => Some("main".into()),
+            Role::Mark => Some("mark".into()),
+            Role::Marquee => Some("marquee".into()),
+            Role::Math => Some("math".into()),
+            Role::MenuBar => Some("menubar".into()),
+            Role::MenuItemCheckBox => Some("menuitemcheckbox".into()),
+            Role::MenuItemRadio => Some("menuitemradio".into()),
+            Role::Meter => Some("meter".into()),
+            Role::Navigation => Some("navigation".into()),
+            Role::Note => Some("note".into()),
+            Role::ProgressIndicator => Some("progressbar".into()),
+            Role::RadioGroup => Some("radiogroup".into()),
+            Role::Region => Some("region".into()),
+            Role::ScrollBar => Some("scrollbar".into()),
+            Role::Search => Some("search".into()),
+            Role::Section => Some("section".into()),
+            Role::Slider => Some("slider".into()),
+            Role::SpinButton => Some("spinbutton".into()),
+            Role::Splitter => Some("separator".into()),
+            Role::Status => Some("status".into()),
+            Role::Strong => Some("strong".into()),
+            Role::Suggestion => Some("suggestion".into()),
+            Role::Tab => Some("tab".into()),
+            Role::TabList => Some("tablist".into()),
+            Role::TabPanel => Some("tabpanel".into()),
+            Role::Term => Some("term".into()),
+            Role::Time => Some("time".into()),
+            Role::Timer => Some("timer".into()),
+            Role::Toolbar => Some("toolbar".into()),
+            Role::Tooltip => Some("tooltip".into()),
+            Role::Tree => Some("tree".into()),
+            Role::TreeGrid => Some("treegrid".into()),
+            Role::Window => Some("window".into()),
+            Role::GraphicsDocument => Some("graphics-document".into()),
+            Role::GraphicsObject => Some("graphics-object".into()),
+            Role::GraphicsSymbol => Some("graphics-symbol".into()),
+            Role::DocAbstract => Some("doc-abstract".into()),
+            Role::DocAcknowledgements => Some("doc-acknowledgements".into()),
+            Role::DocAfterword => Some("doc-afterword".into()),
+            Role::DocAppendix => Some("doc-appendix".into()),
+            Role::DocBackLink => Some("doc-backlink".into()),
+            Role::DocBiblioEntry => Some("doc-biblioentry".into()),
+            Role::DocBibliography => Some("doc-bibliography".into()),
+            Role::DocBiblioRef => Some("doc-biblioref".into()),
+            Role::DocChapter => Some("doc-chapter".into()),
+            Role::DocColophon => Some("doc-colophon".into()),
+            Role::DocConclusion => Some("doc-conclusion".into()),
+            Role::DocCover => Some("doc-cover".into()),
+            Role::DocCredit => Some("doc-credit".into()),
+            Role::DocCredits => Some("doc-credits".into()),
+            Role::DocDedication => Some("doc-dedication".into()),
+            Role::DocEndnote => Some("doc-endnote".into()),
+            Role::DocEndnotes => Some("doc-endnotes".into()),
+            Role::DocEpigraph => Some("doc-epigraph".into()),
+            Role::DocEpilogue => Some("doc-epilogue".into()),
+            Role::DocErrata => Some("doc-errata".into()),
+            Role::DocExample => Some("doc-example".into()),
+            Role::DocFootnote => Some("doc-footnote".into()),
+            Role::DocForeword => Some("doc-forward".into()),
+            Role::DocGlossary => Some("doc-glossary".into()),
+            Role::DocGlossRef => Some("doc-glossref".into()),
+            Role::DocIndex => Some("doc-index".into()),
+            Role::DocIntroduction => Some("doc-introduction".into()),
+            Role::DocNoteRef => Some("doc-noteref".into()),
+            Role::DocNotice => Some("doc-notice".into()),
+            Role::DocPageBreak => Some("doc-pagebreak".into()),
+            Role::DocPageFooter => Some("doc-pagefooter".into()),
+            Role::DocPageHeader => Some("doc-pageheader".into()),
+            Role::DocPageList => Some("doc-pagelist".into()),
+            Role::DocPart => Some("doc-part".into()),
+            Role::DocPreface => Some("doc-preface".into()),
+            Role::DocPrologue => Some("doc-prologue".into()),
+            Role::DocPullquote => Some("doc-pullquote".into()),
+            Role::DocQna => Some("doc-qna".into()),
+            Role::DocSubtitle => Some("doc-subtitle".into()),
+            Role::DocTip => Some("doc-tip".into()),
+            Role::DocToc => Some("doc-toc".into()),
+            _ => None,
+        }
+    }
+
+    fn tabindex(&self) -> Option<String> {
+        self.0.is_focusable(&filter).then(|| "-1".into())
+    }
+
+    fn label(&self) -> Option<String> {
+        self.0.label()
+    }
+
+    fn aria_label(&self) -> Option<String> {
+        if self.0.role() == Role::Label {
+            return None;
+        }
+        self.label()
+    }
+
+    fn text_content(&self) -> Option<String> {
+        if self.0.role() != Role::Label {
+            return None;
+        }
+        self.label()
+    }
+
+    fn aria_checked(&self) -> Option<String> {
+        self.0.toggled().map(|value| match value {
+            Toggled::False => "false".into(),
+            Toggled::True => "true".into(),
+            Toggled::Mixed => "mixed".into(),
+        })
+    }
+
+    fn aria_valuemax(&self) -> Option<String> {
+        self.0.max_numeric_value().map(|value| value.to_string())
+    }
+
+    fn aria_valuemin(&self) -> Option<String> {
+        self.0.min_numeric_value().map(|value| value.to_string())
+    }
+
+    fn aria_valuenow(&self) -> Option<String> {
+        self.0.numeric_value().map(|value| value.to_string())
+    }
+
+    fn aria_valuetext(&self) -> Option<String> {
+        self.0.value()
+    }
+}
+
+macro_rules! attributes {
+    ($(($name:literal, $m:ident)),+) => {
+        impl NodeWrapper<'_> {
+            pub(crate) fn set_all_attributes(&self, element: &HtmlElement) {
+                $(let value = self.$m();
+                if let Some(value) = value.as_ref() {
+                    let _ = element.set_attribute($name, value);
+                })*
+                if let Some(text_content) = self.text_content().as_ref() {
+                    element.set_text_content(Some(text_content));
+                }
+            }
+
+            pub(crate) fn update_attributes(&self, element: &HtmlElement, old: &NodeWrapper<'_>) {
+                $({
+                    let old_value = old.$m();
+                    let new_value = self.$m();
+                    if old_value != new_value {
+                        if let Some(value) = new_value.as_ref() {
+                            let _ = element.set_attribute($name, value);
+                        } else {
+                            let _ = element.remove_attribute($name);
+                        }
+                    }
+                })*
+                let old_text_content = old.text_content();
+                let new_text_content = self.text_content();
+                if old_text_content != new_text_content {
+                    element.set_text_content(new_text_content.as_deref());
+                }
+            }
+        }
+    };
+}
+
+attributes! {
+    ("role", role),
+    ("tabindex", tabindex),
+    ("aria-label", aria_label),
+    ("aria-checked", aria_checked),
+    ("aria-valuemax", aria_valuemax),
+    ("aria-valuemin", aria_valuemin),
+    ("aria-valuenow", aria_valuenow),
+    ("aria-valuetext", aria_valuetext)
+}

--- a/crates/accesskit-web/src/node.rs
+++ b/crates/accesskit-web/src/node.rs
@@ -5,15 +5,20 @@
 
 use accesskit::{Role, Toggled};
 use accesskit_consumer::Node;
+use core::fmt::Write as _;
 use web_sys::HtmlElement;
 
 use crate::filters::filter;
 
-pub(crate) struct NodeWrapper<'a>(pub(crate) Node<'a>);
+pub(crate) struct NodeWrapper<'a> {
+    pub(crate) node: Node<'a>,
+    /// Draw a green outline around every mirrored node.
+    pub(crate) debug: bool,
+}
 
 impl NodeWrapper<'_> {
     fn role(&self) -> Option<String> {
-        let role = self.0.role();
+        let role = self.node.role();
         match role {
             Role::Cell => Some("cell".into()),
             Role::Image => Some("img".into()),
@@ -153,34 +158,73 @@ impl NodeWrapper<'_> {
             Role::DocSubtitle => Some("doc-subtitle".into()),
             Role::DocTip => Some("doc-tip".into()),
             Role::DocToc => Some("doc-toc".into()),
+            // Plain text with no role is merged into its neighbours by Safari
+            // (flutter#166787), so say what it is.
+            Role::Label => Some("paragraph".into()),
             _ => None,
         }
     }
 
+    /// Where the mirror element goes, in the physical pixels the tree uses.
+    ///
+    /// The host scales the whole mirror back to CSS pixels in one go, so no
+    /// division happens here.
+    ///
+    /// A node's element is nested inside its parent's, and an absolutely
+    /// positioned parent is the containing block of its absolutely positioned
+    /// children, so the offsets have to be relative to the nearest mirrored
+    /// ancestor that has a box. Flutter's semantics layer does the same.
+    fn style(&self) -> Option<String> {
+        let mut style = String::from("position:absolute;overflow:visible;");
+        match self.node.bounding_box() {
+            Some(bounds) => {
+                let (origin_x, origin_y) = ancestor_origin(&self.node);
+                write!(
+                    style,
+                    "left:{}px;top:{}px;width:{}px;height:{}px;",
+                    bounds.x0 - origin_x,
+                    bounds.y0 - origin_y,
+                    bounds.width(),
+                    bounds.height()
+                )
+                .ok()?;
+            }
+            // No box of its own: sit on the ancestor's origin so that the
+            // children below it keep their coordinates.
+            None => style.push_str("left:0;top:0;"),
+        }
+        if self.debug {
+            // An outline, not a border: a border would move the layout.
+            style.push_str("outline:1px solid green;");
+        }
+        Some(style)
+    }
+
+    /// Focusable nodes are Tab stops, in tree order, which is DOM order.
     fn tabindex(&self) -> Option<String> {
-        self.0.is_focusable(&filter).then(|| "-1".into())
+        self.node.is_focusable(&filter).then(|| "0".into())
     }
 
     fn label(&self) -> Option<String> {
-        self.0.label()
+        self.node.label()
     }
 
     fn aria_label(&self) -> Option<String> {
-        if self.0.role() == Role::Label {
+        if self.node.role() == Role::Label {
             return None;
         }
         self.label()
     }
 
     fn text_content(&self) -> Option<String> {
-        if self.0.role() != Role::Label {
+        if self.node.role() != Role::Label {
             return None;
         }
         self.label()
     }
 
     fn aria_checked(&self) -> Option<String> {
-        self.0.toggled().map(|value| match value {
+        self.node.toggled().map(|value| match value {
             Toggled::False => "false".into(),
             Toggled::True => "true".into(),
             Toggled::Mixed => "mixed".into(),
@@ -188,25 +232,33 @@ impl NodeWrapper<'_> {
     }
 
     fn aria_valuemax(&self) -> Option<String> {
-        self.0.max_numeric_value().map(|value| value.to_string())
+        self.node.max_numeric_value().map(|value| value.to_string())
     }
 
     fn aria_valuemin(&self) -> Option<String> {
-        self.0.min_numeric_value().map(|value| value.to_string())
+        self.node.min_numeric_value().map(|value| value.to_string())
     }
 
     fn aria_valuenow(&self) -> Option<String> {
-        self.0.numeric_value().map(|value| value.to_string())
+        self.node.numeric_value().map(|value| value.to_string())
     }
 
     fn aria_valuetext(&self) -> Option<String> {
-        self.0.value()
+        self.node.value()
     }
 }
 
 macro_rules! attributes {
     ($(($name:literal, $m:ident)),+) => {
         impl NodeWrapper<'_> {
+            /// Rewrite only the position, for when the mirror's own settings
+            /// changed rather than the tree.
+            pub(crate) fn set_style(&self, element: &HtmlElement) {
+                if let Some(style) = self.style().as_ref() {
+                    let _ = element.set_attribute("style", style);
+                }
+            }
+
             pub(crate) fn set_all_attributes(&self, element: &HtmlElement) {
                 $(let value = self.$m();
                 if let Some(value) = value.as_ref() {
@@ -239,7 +291,21 @@ macro_rules! attributes {
     };
 }
 
+/// The origin the node's own coordinates are written against: the nearest
+/// mirrored ancestor that has a bounding box, or the mirror host.
+fn ancestor_origin(node: &Node<'_>) -> (f64, f64) {
+    let mut ancestor = node.filtered_parent(&filter);
+    while let Some(current) = ancestor {
+        if let Some(bounds) = current.bounding_box() {
+            return (bounds.x0, bounds.y0);
+        }
+        ancestor = current.filtered_parent(&filter);
+    }
+    (0.0, 0.0)
+}
+
 attributes! {
+    ("style", style),
     ("role", role),
     ("tabindex", tabindex),
     ("aria-label", aria_label),

--- a/crates/accesskit-web/src/node.rs
+++ b/crates/accesskit-web/src/node.rs
@@ -6,9 +6,53 @@
 use accesskit::{Role, Toggled};
 use accesskit_consumer::Node;
 use core::fmt::Write as _;
-use web_sys::HtmlElement;
+use wasm_bindgen::JsCast as _;
+use web_sys::{HtmlElement, HtmlInputElement};
 
 use crate::filters::filter;
+
+/// Which DOM element stands for a node.
+///
+/// Most of the mirror is `<div>`s with an ARIA role, the way Flutter's
+/// semantics layer builds it. Two roles need a real control instead: a
+/// `<div role="slider">` has no value for a screen reader to *set*, so it
+/// never fires `input` or `change` and `Action::SetValue` could never leave
+/// the DOM. Flutter draws the same line in the same place — real elements for
+/// sliders and text fields, `role` + `aria-checked` for checkboxes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ElementKind {
+    Div,
+    /// `<input type="range">` — a slider assistive technology can move.
+    Range,
+    /// `<input type="text" readonly>` — reads its value out, but never takes
+    /// the typing: that goes to eframe's own hidden `<input>` (the text
+    /// agent), which is what egui listens to.
+    Text,
+}
+
+impl ElementKind {
+    pub(crate) fn tag_name(self) -> &'static str {
+        match self {
+            Self::Div => "div",
+            Self::Range | Self::Text => "input",
+        }
+    }
+
+    /// The attributes that make the element what it is, set once when it is
+    /// created. Everything else is written by [`NodeWrapper`] every update.
+    pub(crate) fn init(self, element: &HtmlElement) {
+        match self {
+            Self::Div => {}
+            Self::Range => {
+                let _ = element.set_attribute("type", "range");
+            }
+            Self::Text => {
+                let _ = element.set_attribute("type", "text");
+                let _ = element.set_attribute("readonly", "");
+            }
+        }
+    }
+}
 
 pub(crate) struct NodeWrapper<'a> {
     pub(crate) node: Node<'a>,
@@ -205,6 +249,65 @@ impl NodeWrapper<'_> {
         self.node.is_focusable(&filter).then(|| "0".into())
     }
 
+    /// A `<div>` unless the node carries a value a screen reader can set or
+    /// read as text. See [`ElementKind`].
+    pub(crate) fn element_kind(&self) -> ElementKind {
+        match self.node.role() {
+            Role::Slider | Role::SpinButton => ElementKind::Range,
+            Role::TextInput => ElementKind::Text,
+            _ => ElementKind::Div,
+        }
+    }
+
+    fn input_min(&self) -> Option<String> {
+        (self.element_kind() == ElementKind::Range)
+            .then(|| self.node.min_numeric_value())
+            .flatten()
+            .map(|value| value.to_string())
+    }
+
+    fn input_max(&self) -> Option<String> {
+        (self.element_kind() == ElementKind::Range)
+            .then(|| self.node.max_numeric_value())
+            .flatten()
+            .map(|value| value.to_string())
+    }
+
+    /// A range without a step snaps to whole numbers, which would round every
+    /// float slider egui has. `any` is the way out.
+    fn input_step(&self) -> Option<String> {
+        (self.element_kind() == ElementKind::Range).then(|| {
+            self.node
+                .numeric_value_step()
+                .map_or_else(|| "any".into(), |step| step.to_string())
+        })
+    }
+
+    /// What the control shows. Written as a property rather than an
+    /// attribute: once assistive technology has moved a range, the attribute
+    /// only sets `defaultValue` and the shown value would stop following the
+    /// app.
+    fn input_value(&self) -> Option<String> {
+        match self.element_kind() {
+            ElementKind::Div => None,
+            ElementKind::Range => self.node.numeric_value().map(|value| value.to_string()),
+            ElementKind::Text => self.node.value(),
+        }
+    }
+
+    /// Push the value onto a real control, if it is not already showing it.
+    fn set_input_value(&self, element: &HtmlElement) {
+        let Some(input) = element.dyn_ref::<HtmlInputElement>() else {
+            return;
+        };
+        let Some(value) = self.input_value() else {
+            return;
+        };
+        if input.value() != value {
+            input.set_value(&value);
+        }
+    }
+
     fn label(&self) -> Option<String> {
         self.node.label()
     }
@@ -277,6 +380,7 @@ macro_rules! attributes {
                 if let Some(text_content) = self.text_content().as_ref() {
                     element.set_text_content(Some(text_content));
                 }
+                self.set_input_value(element);
             }
 
             pub(crate) fn update_attributes(&self, element: &HtmlElement, old: &NodeWrapper<'_>) {
@@ -296,6 +400,7 @@ macro_rules! attributes {
                 if old_text_content != new_text_content {
                     element.set_text_content(new_text_content.as_deref());
                 }
+                self.set_input_value(element);
             }
         }
     };
@@ -320,8 +425,14 @@ attributes! {
     ("tabindex", tabindex),
     ("aria-label", aria_label),
     ("aria-checked", aria_checked),
+    // Both the ARIA values and the real `<input>` ones: the ARIA pair is what
+    // a `<div role="slider">` is read from, and it stays right for the real
+    // control too, since the two are written from the same numbers.
     ("aria-valuemax", aria_valuemax),
     ("aria-valuemin", aria_valuemin),
     ("aria-valuenow", aria_valuenow),
-    ("aria-valuetext", aria_valuetext)
+    ("aria-valuetext", aria_valuetext),
+    ("min", input_min),
+    ("max", input_max),
+    ("step", input_step)
 }

--- a/crates/accesskit-web/src/node.rs
+++ b/crates/accesskit-web/src/node.rs
@@ -216,11 +216,17 @@ impl NodeWrapper<'_> {
         self.label()
     }
 
+    /// A piece of static text reads as its text content, not as a name on an
+    /// empty box.
+    ///
+    /// A `Role::Label` node carries its text in `value`, not in `label` — that
+    /// is what `Node::label_comes_from_value` is about, and it is how egui
+    /// writes its labels — so ask for both.
     fn text_content(&self) -> Option<String> {
         if self.node.role() != Role::Label {
             return None;
         }
-        self.label()
+        self.label().or_else(|| self.node.value())
     }
 
     fn aria_checked(&self) -> Option<String> {
@@ -244,6 +250,10 @@ impl NodeWrapper<'_> {
     }
 
     fn aria_valuetext(&self) -> Option<String> {
+        // Text that is already the element's text content is not also a value.
+        if self.node.label_comes_from_value() {
+            return None;
+        }
         self.node.value()
     }
 }

--- a/crates/accesskit-web/tests/mirror.rs
+++ b/crates/accesskit-web/tests/mirror.rs
@@ -20,8 +20,9 @@ use accesskit::{
     Action, Node as AkNode, NodeId, Rect, Role, Toggled, Tree, TreeId, TreeUpdate, Uuid,
 };
 use accesskit_web::Adapter;
+use wasm_bindgen::JsCast as _;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-use web_sys::Element;
+use web_sys::{Element, HtmlInputElement};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -29,12 +30,14 @@ const ROOT: NodeId = NodeId(0);
 const BUTTON: NodeId = NodeId(1);
 const CHECKBOX: NodeId = NodeId(2);
 const LABEL: NodeId = NodeId(3);
+const SLIDER: NodeId = NodeId(4);
 
-/// A window with a button, a checkbox and a piece of text, all with boxes.
+/// A window with a button, a checkbox, a piece of text and a slider, all with
+/// boxes.
 fn initial_tree() -> TreeUpdate {
     let mut root = AkNode::new(Role::Window);
     root.set_bounds(Rect::new(0.0, 0.0, 200.0, 100.0));
-    root.set_children(vec![BUTTON, CHECKBOX, LABEL]);
+    root.set_children(vec![BUTTON, CHECKBOX, LABEL, SLIDER]);
 
     let mut button = AkNode::new(Role::Button);
     button.set_label("increment");
@@ -51,12 +54,22 @@ fn initial_tree() -> TreeUpdate {
     label.set_label("hello");
     label.set_bounds(Rect::new(70.0, 20.0, 120.0, 40.0));
 
+    let mut slider = AkNode::new(Role::Slider);
+    slider.set_label("volume");
+    slider.set_numeric_value(50.0);
+    slider.set_min_numeric_value(0.0);
+    slider.set_max_numeric_value(100.0);
+    slider.set_numeric_value_step(1.0);
+    slider.set_bounds(Rect::new(10.0, 75.0, 110.0, 95.0));
+    slider.add_action(Action::SetValue);
+
     TreeUpdate {
         nodes: vec![
             (ROOT, root),
             (BUTTON, button),
             (CHECKBOX, checkbox),
             (LABEL, label),
+            (SLIDER, slider),
         ],
         tree: Some(Tree::new(ROOT)),
         tree_id: TreeId::ROOT,
@@ -235,4 +248,62 @@ fn elements_say_which_node_they_stand_for() {
         button.get_attribute("data-accesskit-tree").as_deref(),
         Some(Uuid::nil().as_u128().to_string().as_str())
     );
+}
+
+#[wasm_bindgen_test]
+fn a_slider_is_a_real_range_input() {
+    let container = container();
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+
+    // A `<div role="slider">` has no value to change, so `input`/`change`
+    // would never fire and `Action::SetValue` could never leave the DOM.
+    let slider = query(&container, "[role=\"slider\"]").expect("the slider is mirrored");
+    assert_eq!(slider.tag_name(), "INPUT");
+    assert_eq!(slider.get_attribute("type").as_deref(), Some("range"));
+    assert_eq!(slider.get_attribute("min").as_deref(), Some("0"));
+    assert_eq!(slider.get_attribute("max").as_deref(), Some("100"));
+    assert_eq!(slider.get_attribute("step").as_deref(), Some("1"));
+
+    // The value is a property, not an attribute: once assistive technology
+    // has moved the range, the attribute is only its default.
+    let input = slider.unchecked_ref::<HtmlInputElement>();
+    assert_eq!(input.value(), "50");
+
+    // The ARIA pair is written too, for the roles that stay `<div>`s and for
+    // anything that reads the node rather than the control.
+    assert_eq!(slider.get_attribute("aria-valuenow").as_deref(), Some("50"));
+    assert_eq!(slider.get_attribute("aria-valuemin").as_deref(), Some("0"));
+    assert_eq!(
+        slider.get_attribute("aria-valuemax").as_deref(),
+        Some("100")
+    );
+    assert_eq!(
+        slider.get_attribute("aria-label").as_deref(),
+        Some("volume")
+    );
+}
+
+#[wasm_bindgen_test]
+fn a_slider_follows_the_app() {
+    let container = container();
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+
+    let slider = query(&container, "[role=\"slider\"]").expect("the slider is mirrored");
+    let input = slider.unchecked_ref::<HtmlInputElement>();
+    // Assistive technology moved it; the app has not agreed yet.
+    input.set_value("80");
+
+    adapter.update_if_active(|| {
+        let mut update = initial_tree();
+        for (id, node) in &mut update.nodes {
+            if *id == SLIDER {
+                node.set_numeric_value(70.0);
+            }
+        }
+        update
+    });
+
+    assert_eq!(input.value(), "70", "the app has the last word");
 }

--- a/crates/accesskit-web/tests/mirror.rs
+++ b/crates/accesskit-web/tests/mirror.rs
@@ -77,12 +77,21 @@ fn initial_tree() -> TreeUpdate {
     }
 }
 
-/// A fresh element under `<body>` to hang one test's mirror on.
+/// A fresh element under `<body>` to hang one test's mirror on, with a
+/// stand-in for the canvas the app draws on: the mirror goes next to it, and
+/// it is the one element that ever holds the browser's focus.
 fn container() -> Element {
     let document = web_sys::window().unwrap().document().unwrap();
     let container = document.create_element("div").unwrap();
+    let canvas = document.create_element("canvas").unwrap();
+    canvas.set_attribute("tabindex", "0").unwrap();
+    container.append_child(&canvas).unwrap();
     document.body().unwrap().append_child(&container).unwrap();
     container
+}
+
+fn canvas(container: &Element) -> Element {
+    query(container, "canvas").expect("the container has a canvas")
 }
 
 fn mirror(container: &Element) -> Adapter {
@@ -96,7 +105,7 @@ fn mirror(container: &Element) -> Adapter {
     impl accesskit::ActionHandler for DropActions {
         fn do_action(&mut self, _request: accesskit::ActionRequest) {}
     }
-    Adapter::new(container, NoActivation, DropActions).unwrap()
+    Adapter::new(container, &canvas(container), NoActivation, DropActions).unwrap()
 }
 
 fn query(container: &Element, selector: &str) -> Option<Element> {
@@ -118,8 +127,9 @@ fn roles_labels_and_values_reach_the_dom() {
         button.get_attribute("aria-label").as_deref(),
         Some("increment")
     );
-    // Focusable nodes are Tab stops, in tree order.
-    assert_eq!(button.get_attribute("tabindex").as_deref(), Some("0"));
+    // A focusable node says so, but is never a tab stop: the browser's focus
+    // belongs to the canvas, and egui moves between widgets itself.
+    assert_eq!(button.get_attribute("tabindex").as_deref(), Some("-1"));
 
     let checkbox = query(&container, "[role=\"checkbox\"]").expect("the checkbox is mirrored");
     assert_eq!(
@@ -147,9 +157,7 @@ fn nodes_are_placed_at_their_bounding_boxes() {
 
     // The host takes the whole mirror back to CSS pixels in one go, and lets
     // the mouse through to the canvas underneath.
-    let host = container
-        .first_element_child()
-        .expect("the mirror has a host");
+    let host = query(&container, "[id$=\"-host\"]").expect("the mirror has a host");
     let host_style = style_of(&host);
     assert!(host_style.contains("transform:scale(0.5)"), "{host_style}");
     assert!(host_style.contains("pointer-events:none"), "{host_style}");
@@ -306,4 +314,112 @@ fn a_slider_follows_the_app() {
     });
 
     assert_eq!(input.value(), "70", "the app has the last word");
+}
+
+/// The tree focuses `node`, everything else as in [`initial_tree`].
+fn tree_focused_on(node: NodeId) -> TreeUpdate {
+    TreeUpdate {
+        focus: node,
+        ..initial_tree()
+    }
+}
+
+#[wasm_bindgen_test]
+fn focus_is_named_on_the_canvas_not_taken_from_it() {
+    let container = container();
+    let canvas = canvas(&container);
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+    adapter.update_if_active(|| tree_focused_on(BUTTON));
+
+    // The reference is only legal because the canvas owns the host, which is
+    // its sibling rather than its child.
+    let host = query(&container, "[id$=\"-host\"]").expect("the mirror has a host");
+    assert_eq!(
+        canvas.get_attribute("aria-owns").as_deref(),
+        host.get_attribute("id").as_deref()
+    );
+    assert_eq!(canvas.get_attribute("role").as_deref(), Some("application"));
+
+    let button = query(&container, "[role=\"button\"]").expect("the button is mirrored");
+    assert_eq!(
+        canvas.get_attribute("aria-activedescendant").as_deref(),
+        button.get_attribute("id").as_deref()
+    );
+    // Nothing in the mirror ever takes the browser's focus.
+    let document = web_sys::window().unwrap().document().unwrap();
+    assert!(
+        document
+            .active_element()
+            .is_none_or(|active| active != button),
+        "the mirror never calls focus()"
+    );
+    assert_eq!(
+        button.get_attribute("data-focused").as_deref(),
+        Some("true")
+    );
+
+    // Moving on takes the marker with it.
+    adapter.update_if_active(|| tree_focused_on(CHECKBOX));
+    let checkbox = query(&container, "[role=\"checkbox\"]").expect("the checkbox is mirrored");
+    assert_eq!(
+        canvas.get_attribute("aria-activedescendant").as_deref(),
+        checkbox.get_attribute("id").as_deref()
+    );
+    assert!(button.get_attribute("data-focused").is_none());
+}
+
+#[wasm_bindgen_test]
+fn losing_the_browser_focus_does_not_forget_where_the_app_was() {
+    let container = container();
+    let canvas = canvas(&container);
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(|| tree_focused_on(BUTTON));
+    let button = query(&container, "[role=\"button\"]").expect("the button is mirrored");
+    let focused = canvas.get_attribute("aria-activedescendant");
+    assert_eq!(focused.as_deref(), button.get_attribute("id").as_deref());
+
+    // Clearing the attribute here would be this design's `blur()`, which is
+    // the mistake Flutter's semantics layer warns about.
+    adapter.update_host_focus_state(false);
+    assert_eq!(canvas.get_attribute("aria-activedescendant"), focused);
+
+    adapter.update_host_focus_state(true);
+    assert_eq!(canvas.get_attribute("aria-activedescendant"), focused);
+}
+
+#[wasm_bindgen_test]
+fn a_focused_node_leaving_takes_the_reference_with_it() {
+    let container = container();
+    let canvas = canvas(&container);
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(|| tree_focused_on(CHECKBOX));
+    assert!(canvas.has_attribute("aria-activedescendant"));
+
+    // The checkbox is gone and the focus is back on the window.
+    adapter.update_if_active(|| {
+        let mut root = AkNode::new(Role::Window);
+        root.set_bounds(Rect::new(0.0, 0.0, 200.0, 100.0));
+        root.set_children(vec![BUTTON]);
+
+        let mut button = AkNode::new(Role::Button);
+        button.set_label("increment");
+        button.set_bounds(Rect::new(10.0, 20.0, 60.0, 40.0));
+        button.add_action(Action::Click);
+        button.add_action(Action::Focus);
+
+        TreeUpdate {
+            nodes: vec![(ROOT, root), (BUTTON, button)],
+            tree: Some(Tree::new(ROOT)),
+            tree_id: TreeId::ROOT,
+            focus: ROOT,
+        }
+    });
+
+    let window = query(&container, "[role=\"window\"]").expect("the root is mirrored");
+    assert_eq!(
+        canvas.get_attribute("aria-activedescendant").as_deref(),
+        window.get_attribute("id").as_deref(),
+        "a dangling reference is worse than none"
+    );
 }

--- a/crates/accesskit-web/tests/mirror.rs
+++ b/crates/accesskit-web/tests/mirror.rs
@@ -1,0 +1,238 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+//! What the mirror puts in the document, checked against a handmade tree.
+//!
+//! There is no egui here: the adapter only ever sees an `accesskit::TreeUpdate`.
+//!
+//! These need a browser, so the file is empty everywhere else and
+//! `cargo test --workspace` has nothing to run. To run them:
+//!
+//! ```sh
+//! wasm-pack test --headless --chrome crates/accesskit-web
+//! ```
+
+#![cfg(target_arch = "wasm32")]
+
+use accesskit::{
+    Action, Node as AkNode, NodeId, Rect, Role, Toggled, Tree, TreeId, TreeUpdate, Uuid,
+};
+use accesskit_web::Adapter;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::Element;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const ROOT: NodeId = NodeId(0);
+const BUTTON: NodeId = NodeId(1);
+const CHECKBOX: NodeId = NodeId(2);
+const LABEL: NodeId = NodeId(3);
+
+/// A window with a button, a checkbox and a piece of text, all with boxes.
+fn initial_tree() -> TreeUpdate {
+    let mut root = AkNode::new(Role::Window);
+    root.set_bounds(Rect::new(0.0, 0.0, 200.0, 100.0));
+    root.set_children(vec![BUTTON, CHECKBOX, LABEL]);
+
+    let mut button = AkNode::new(Role::Button);
+    button.set_label("increment");
+    button.set_bounds(Rect::new(10.0, 20.0, 60.0, 40.0));
+    button.add_action(Action::Click);
+    button.add_action(Action::Focus);
+
+    let mut checkbox = AkNode::new(Role::CheckBox);
+    checkbox.set_label("done");
+    checkbox.set_toggled(Toggled::True);
+    checkbox.set_bounds(Rect::new(10.0, 50.0, 30.0, 70.0));
+
+    let mut label = AkNode::new(Role::Label);
+    label.set_label("hello");
+    label.set_bounds(Rect::new(70.0, 20.0, 120.0, 40.0));
+
+    TreeUpdate {
+        nodes: vec![
+            (ROOT, root),
+            (BUTTON, button),
+            (CHECKBOX, checkbox),
+            (LABEL, label),
+        ],
+        tree: Some(Tree::new(ROOT)),
+        tree_id: TreeId::ROOT,
+        focus: ROOT,
+    }
+}
+
+/// A fresh element under `<body>` to hang one test's mirror on.
+fn container() -> Element {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let container = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&container).unwrap();
+    container
+}
+
+fn mirror(container: &Element) -> Adapter {
+    struct NoActivation;
+    impl accesskit::ActivationHandler for NoActivation {
+        fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+            None
+        }
+    }
+    struct DropActions;
+    impl accesskit::ActionHandler for DropActions {
+        fn do_action(&mut self, _request: accesskit::ActionRequest) {}
+    }
+    Adapter::new(container, NoActivation, DropActions).unwrap()
+}
+
+fn query(container: &Element, selector: &str) -> Option<Element> {
+    container.query_selector(selector).unwrap()
+}
+
+fn style_of(element: &Element) -> String {
+    element.get_attribute("style").unwrap_or_default()
+}
+
+#[wasm_bindgen_test]
+fn roles_labels_and_values_reach_the_dom() {
+    let container = container();
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+
+    let button = query(&container, "[role=\"button\"]").expect("the button is mirrored");
+    assert_eq!(
+        button.get_attribute("aria-label").as_deref(),
+        Some("increment")
+    );
+    // Focusable nodes are Tab stops, in tree order.
+    assert_eq!(button.get_attribute("tabindex").as_deref(), Some("0"));
+
+    let checkbox = query(&container, "[role=\"checkbox\"]").expect("the checkbox is mirrored");
+    assert_eq!(
+        checkbox.get_attribute("aria-checked").as_deref(),
+        Some("true")
+    );
+    assert_eq!(
+        checkbox.get_attribute("aria-label").as_deref(),
+        Some("done")
+    );
+
+    // Text is text content, not `aria-label`, and says what it is so that
+    // Safari does not merge it into its neighbours.
+    let label = query(&container, "[role=\"paragraph\"]").expect("the text is mirrored");
+    assert_eq!(label.text_content().as_deref(), Some("hello"));
+    assert!(label.get_attribute("aria-label").is_none());
+}
+
+#[wasm_bindgen_test]
+fn nodes_are_placed_at_their_bounding_boxes() {
+    let container = container();
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+    adapter.set_viewport((0.0, 0.0), 2.0);
+
+    // The host takes the whole mirror back to CSS pixels in one go, and lets
+    // the mouse through to the canvas underneath.
+    let host = container
+        .first_element_child()
+        .expect("the mirror has a host");
+    let host_style = style_of(&host);
+    assert!(host_style.contains("transform:scale(0.5)"), "{host_style}");
+    assert!(host_style.contains("pointer-events:none"), "{host_style}");
+
+    // The window is the root of the tree, so its own box is where the mirror
+    // starts.
+    let window = query(&container, "[role=\"window\"]").expect("the root is mirrored");
+    let window_style = style_of(&window);
+    assert!(window_style.contains("left:0px;top:0px;"), "{window_style}");
+    assert!(
+        window_style.contains("width:200px;height:100px;"),
+        "{window_style}"
+    );
+
+    // A child's box is relative to its parent's: an absolutely positioned
+    // parent is the containing block of its absolutely positioned children.
+    let button = query(&container, "[role=\"button\"]").expect("the button is mirrored");
+    let button_style = style_of(&button);
+    assert!(
+        button_style.contains("position:absolute;"),
+        "{button_style}"
+    );
+    assert!(
+        button_style.contains("left:10px;top:20px;"),
+        "{button_style}"
+    );
+    assert!(
+        button_style.contains("width:50px;height:20px;"),
+        "{button_style}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn an_update_changes_only_what_changed() {
+    let container = container();
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+
+    // The button is renamed and moves; the checkbox goes away.
+    adapter.update_if_active(|| {
+        let mut root = AkNode::new(Role::Window);
+        root.set_bounds(Rect::new(0.0, 0.0, 200.0, 100.0));
+        root.set_children(vec![BUTTON, LABEL]);
+
+        let mut button = AkNode::new(Role::Button);
+        button.set_label("decrement");
+        button.set_bounds(Rect::new(10.0, 25.0, 60.0, 45.0));
+        button.add_action(Action::Click);
+        button.add_action(Action::Focus);
+
+        let mut label = AkNode::new(Role::Label);
+        label.set_label("hello");
+        label.set_bounds(Rect::new(70.0, 20.0, 120.0, 40.0));
+
+        TreeUpdate {
+            nodes: vec![(ROOT, root), (BUTTON, button), (LABEL, label)],
+            tree: Some(Tree::new(ROOT)),
+            tree_id: TreeId::ROOT,
+            focus: ROOT,
+        }
+    });
+
+    let button = query(&container, "[role=\"button\"]").expect("the button is still mirrored");
+    assert_eq!(
+        button.get_attribute("aria-label").as_deref(),
+        Some("decrement")
+    );
+    assert!(
+        style_of(&button).contains("top:25px;"),
+        "{}",
+        style_of(&button)
+    );
+
+    assert!(
+        query(&container, "[role=\"checkbox\"]").is_none(),
+        "a node that left the tree leaves the mirror"
+    );
+    // Untouched nodes keep their element.
+    let label = query(&container, "[role=\"paragraph\"]").expect("the text is still mirrored");
+    assert_eq!(label.text_content().as_deref(), Some("hello"));
+}
+
+#[wasm_bindgen_test]
+fn elements_say_which_node_they_stand_for() {
+    let container = container();
+    let mut adapter = mirror(&container);
+    adapter.update_if_active(initial_tree);
+
+    // What turns a DOM event back into an `ActionRequest`.
+    let button = query(&container, "[role=\"button\"]").expect("the button is mirrored");
+    assert_eq!(
+        button.get_attribute("data-accesskit-node").as_deref(),
+        Some(BUTTON.0.to_string().as_str())
+    );
+    assert_eq!(
+        button.get_attribute("data-accesskit-tree").as_deref(),
+        Some(Uuid::nil().as_u128().to_string().as_str())
+    );
+}

--- a/crates/react-egui-app/Cargo.toml
+++ b/crates/react-egui-app/Cargo.toml
@@ -29,6 +29,17 @@ egui_kittest.workspace = true
 react-egui-elements.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# The DOM mirror of the AccessKit tree. wasm only: on every other target
+# `a11y::WebA11y` is an empty plugin. `accesskit` itself comes from
+# `egui::accesskit`, so the `TreeUpdate` types cannot drift apart.
+accesskit-web.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-web-sys = { workspace = true, features = ["Document", "Element", "HtmlCanvasElement", "Window"] }
+web-sys = { workspace = true, features = [
+    "Document",
+    "DomRect",
+    "Element",
+    "HtmlCanvasElement",
+    "Location",
+    "Window",
+] }

--- a/crates/react-egui-app/src/a11y.rs
+++ b/crates/react-egui-app/src/a11y.rs
@@ -1,0 +1,221 @@
+//! Web accessibility: the egui plugin that drives the DOM mirror.
+//!
+//! egui builds an AccessKit tree for every pass and puts the diff in
+//! `PlatformOutput::accesskit_update`. On native, egui-winit hands that to an
+//! AccessKit adapter and the OS reads it. On the web, eframe throws it away
+//! (`accesskit_update: _, // not currently implemented`), so nothing an app
+//! draws reaches a screen reader.
+//!
+//! [`WebA11y`] picks the tree up before eframe sees it, using egui 0.36's
+//! [`egui::Plugin`] hooks, and hands it to [`accesskit_web::Adapter`], which
+//! mirrors it into hidden DOM elements over the canvas. Nothing here needs a
+//! forked eframe.
+//!
+//! On any target but wasm32 this is an empty plugin, so an app can register it
+//! unconditionally.
+//!
+//! ```ignore
+//! Options {
+//!     setup: Some(Box::new(|cc| {
+//!         cc.egui_ctx.add_plugin(react_egui_app::a11y::WebA11y::new("react_egui_canvas"));
+//!     })),
+//!     ..Default::default()
+//! }
+//! ```
+
+/// Mirrors the app's accessibility tree into the DOM, on the web.
+///
+/// Register it with `Context::add_plugin`, from [`crate::Options::setup`],
+/// where eframe already has its canvas. Registering it turns AccessKit on
+/// (`Context::enable_accesskit`), which costs one `accesskit::Node` per widget
+/// per pass, so an app that does not want to pay that should not register it.
+///
+/// The plugin itself is just a key: `egui::Plugin` is `Send + Sync` and DOM
+/// handles are neither, so everything that touches the document lives in a
+/// thread-local registry. wasm is single-threaded, so nothing is lost.
+pub struct WebA11y {
+    #[cfg(target_arch = "wasm32")]
+    key: usize,
+}
+
+impl WebA11y {
+    /// Mirror the app drawn on the `<canvas>` with this id.
+    ///
+    /// That is [`crate::Options::canvas_id`], which is what the runner passes
+    /// to eframe.
+    pub fn new(canvas_id: impl Into<String>) -> Self {
+        #[cfg(target_arch = "wasm32")]
+        {
+            Self {
+                key: web::register(canvas_id.into()),
+            }
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _: String = canvas_id.into();
+            Self {}
+        }
+    }
+}
+
+impl egui::Plugin for WebA11y {
+    fn debug_name(&self) -> &'static str {
+        "react_egui_web_a11y"
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn setup(&mut self, ctx: &egui::Context) {
+        // egui builds no AccessKit tree until someone asks for one, on every
+        // platform including this one.
+        ctx.enable_accesskit();
+        web::with_mirror(self.key, web::Mirror::attach);
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn output_hook(&mut self, ctx: &egui::Context, output: &mut egui::FullOutput) {
+        let platform_output = &mut output.platform_output;
+
+        // `output_hook` runs once per *pass*, and egui runs a pass again from
+        // the top when it is discarded; react-egui's taffy layout normally
+        // takes two passes (ARCHITECTURE 5.3). The tree of a pass that is
+        // about to be redone describes a layout that will never be drawn, so
+        // drop it. This is the same test `Context::run` breaks its loop on —
+        // `Context::will_discard` cannot be used here, because `end_pass` has
+        // already taken the viewport's output by the time a plugin sees it.
+        let max_passes = ctx.options(|options| options.max_passes.get());
+        let redone = platform_output.requested_discard()
+            && platform_output.num_completed_passes < max_passes;
+        if redone {
+            platform_output.accesskit_update = None;
+            return;
+        }
+
+        let Some(update) = platform_output.accesskit_update.take() else {
+            return;
+        };
+        // eframe pulls the canvas's focus back every frame, so this is "is the
+        // app focused" rather than "is a mirror element focused".
+        let is_focused = ctx.input(|input| input.focused);
+        let pixels_per_point = f64::from(ctx.pixels_per_point());
+        web::with_mirror(self.key, |mirror| {
+            mirror.frame(update, is_focused, pixels_per_point);
+        });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod web {
+    use accesskit_web::Adapter;
+    use egui::accesskit::{ActionHandler, ActionRequest, ActivationHandler, TreeUpdate};
+    use std::cell::RefCell;
+
+    // Everything that is `!Send`: one entry per registered plugin.
+    thread_local! {
+        static MIRRORS: RefCell<Vec<Mirror>> = const { RefCell::new(Vec::new()) };
+    }
+
+    pub(super) fn register(canvas_id: String) -> usize {
+        MIRRORS.with_borrow_mut(|mirrors| {
+            mirrors.push(Mirror {
+                canvas_id,
+                canvas: None,
+                adapter: None,
+                host_focused: None,
+            });
+            mirrors.len() - 1
+        })
+    }
+
+    pub(super) fn with_mirror(key: usize, f: impl FnOnce(&mut Mirror)) {
+        MIRRORS.with_borrow_mut(|mirrors| {
+            if let Some(mirror) = mirrors.get_mut(key) {
+                f(mirror);
+            }
+        });
+    }
+
+    pub(super) struct Mirror {
+        canvas_id: String,
+        canvas: Option<web_sys::Element>,
+        adapter: Option<Adapter>,
+        host_focused: Option<bool>,
+    }
+
+    impl Mirror {
+        /// Put the mirror next to the canvas, so that the two share a
+        /// containing block and one offset lines them up.
+        pub(super) fn attach(&mut self) {
+            if self.adapter.is_some() {
+                return;
+            }
+            let canvas = web_sys::window()
+                .and_then(|window| window.document())
+                .and_then(|document| document.get_element_by_id(&self.canvas_id));
+            let Some(canvas) = canvas else {
+                log::error!(
+                    "react-egui a11y: no <canvas id=\"{}\"> to mirror",
+                    self.canvas_id
+                );
+                return;
+            };
+            let Some(parent) = canvas.parent_element() else {
+                log::error!("react-egui a11y: the canvas has no parent element");
+                return;
+            };
+            let Some(mut adapter) = Adapter::new(&parent, NoActivation, DropActions) else {
+                log::error!("react-egui a11y: no document to build the mirror in");
+                return;
+            };
+            adapter.set_debug(debug_requested());
+            self.canvas = Some(canvas);
+            self.adapter = Some(adapter);
+        }
+
+        /// One frame: line the mirror up, then apply the tree diff.
+        pub(super) fn frame(
+            &mut self,
+            update: TreeUpdate,
+            is_focused: bool,
+            pixels_per_point: f64,
+        ) {
+            let Some(adapter) = self.adapter.as_mut() else {
+                return;
+            };
+            if self.host_focused != Some(is_focused) {
+                self.host_focused = Some(is_focused);
+                adapter.update_host_focus_state(is_focused);
+            }
+            if let Some(canvas) = &self.canvas {
+                let rect = canvas.get_bounding_client_rect();
+                adapter.set_viewport((rect.left(), rect.top()), pixels_per_point);
+            }
+            adapter.update_if_active(|| update);
+        }
+    }
+
+    /// `?a11y-debug` in the URL shows the mirror: no transparency, and a green
+    /// outline around every node.
+    fn debug_requested() -> bool {
+        web_sys::window()
+            .and_then(|window| window.location().search().ok())
+            .is_some_and(|search| search.contains("a11y-debug"))
+    }
+
+    /// The tree is pushed from `output_hook` every frame, so the adapter never
+    /// has to ask for one.
+    struct NoActivation;
+
+    impl ActivationHandler for NoActivation {
+        fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+            None
+        }
+    }
+
+    /// Assistive technology cannot drive the app yet; the way back is the next
+    /// step.
+    struct DropActions;
+
+    impl ActionHandler for DropActions {
+        fn do_action(&mut self, _request: ActionRequest) {}
+    }
+}

--- a/crates/react-egui-app/src/a11y.rs
+++ b/crates/react-egui-app/src/a11y.rs
@@ -68,7 +68,7 @@ impl egui::Plugin for WebA11y {
         // egui builds no AccessKit tree until someone asks for one, on every
         // platform including this one.
         ctx.enable_accesskit();
-        web::with_mirror(self.key, web::Mirror::attach);
+        web::with_mirror(self.key, |mirror| mirror.attach(ctx));
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -101,6 +101,19 @@ impl egui::Plugin for WebA11y {
             mirror.frame(update, is_focused, pixels_per_point);
         });
     }
+
+    #[cfg(target_arch = "wasm32")]
+    fn input_hook(&mut self, _ctx: &egui::Context, input: &mut egui::RawInput) {
+        // Everything a screen reader asked for since the last frame. egui
+        // handles these where the widgets are: a `Click` on a button is the
+        // same as a real one, `SetValue` moves a slider, `Focus` moves the
+        // keyboard focus.
+        web::take_actions(self.key, |request| {
+            input
+                .events
+                .push(egui::Event::AccessKitActionRequest(request));
+        });
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -108,6 +121,7 @@ mod web {
     use accesskit_web::Adapter;
     use egui::accesskit::{ActionHandler, ActionRequest, ActivationHandler, TreeUpdate};
     use std::cell::RefCell;
+    use std::rc::Rc;
 
     // Everything that is `!Send`: one entry per registered plugin.
     thread_local! {
@@ -121,6 +135,7 @@ mod web {
                 canvas: None,
                 adapter: None,
                 host_focused: None,
+                actions: Rc::default(),
             });
             mirrors.len() - 1
         })
@@ -134,17 +149,36 @@ mod web {
         });
     }
 
+    /// Requests arrive from DOM listeners, which fire between frames and
+    /// cannot reach into the registry the adapter itself is stored in. The
+    /// queue is shared with them instead, so draining it never re-enters
+    /// `MIRRORS`.
+    type Actions = Rc<RefCell<Vec<ActionRequest>>>;
+
     pub(super) struct Mirror {
         canvas_id: String,
         canvas: Option<web_sys::Element>,
         adapter: Option<Adapter>,
         host_focused: Option<bool>,
+        actions: Actions,
+    }
+
+    /// Hand egui everything assistive technology asked for since last frame.
+    pub(super) fn take_actions(key: usize, mut push: impl FnMut(ActionRequest)) {
+        let actions =
+            MIRRORS.with_borrow(|mirrors| mirrors.get(key).map(|m| Rc::clone(&m.actions)));
+        let Some(actions) = actions else {
+            return;
+        };
+        for request in actions.borrow_mut().drain(..) {
+            push(request);
+        }
     }
 
     impl Mirror {
         /// Put the mirror next to the canvas, so that the two share a
         /// containing block and one offset lines them up.
-        pub(super) fn attach(&mut self) {
+        pub(super) fn attach(&mut self, ctx: &egui::Context) {
             if self.adapter.is_some() {
                 return;
             }
@@ -162,7 +196,11 @@ mod web {
                 log::error!("react-egui a11y: the canvas has no parent element");
                 return;
             };
-            let Some(mut adapter) = Adapter::new(&parent, NoActivation, DropActions) else {
+            let queue = QueueActions {
+                actions: Rc::clone(&self.actions),
+                ctx: ctx.clone(),
+            };
+            let Some(mut adapter) = Adapter::new(&parent, NoActivation, queue) else {
                 log::error!("react-egui a11y: no document to build the mirror in");
                 return;
             };
@@ -211,11 +249,22 @@ mod web {
         }
     }
 
-    /// Assistive technology cannot drive the app yet; the way back is the next
-    /// step.
-    struct DropActions;
+    /// The adapter's way out: park the request until egui next reads input.
+    ///
+    /// Holding a `Context` is what the `Plugin` docs warn against, but this is
+    /// not the plugin — it is a DOM listener living in a thread-local, which
+    /// the `Context` does not own, so there is no cycle. Without the repaint
+    /// nothing would happen: egui draws on demand, and a screen reader
+    /// activating an element is not an event it knows about.
+    struct QueueActions {
+        actions: Actions,
+        ctx: egui::Context,
+    }
 
-    impl ActionHandler for DropActions {
-        fn do_action(&mut self, _request: ActionRequest) {}
+    impl ActionHandler for QueueActions {
+        fn do_action(&mut self, request: ActionRequest) {
+            self.actions.borrow_mut().push(request);
+            self.ctx.request_repaint();
+        }
     }
 }

--- a/crates/react-egui-app/src/a11y.rs
+++ b/crates/react-egui-app/src/a11y.rs
@@ -200,7 +200,11 @@ mod web {
                 actions: Rc::clone(&self.actions),
                 ctx: ctx.clone(),
             };
-            let Some(mut adapter) = Adapter::new(&parent, NoActivation, queue) else {
+            // The canvas is both where the mirror is lined up and the one
+            // element that holds the browser's focus: eframe pulls focus back
+            // to it every frame, so the mirror says where the app's focus is
+            // with `aria-activedescendant` instead of taking it.
+            let Some(mut adapter) = Adapter::new(&parent, &canvas, NoActivation, queue) else {
                 log::error!("react-egui a11y: no document to build the mirror in");
                 return;
             };

--- a/crates/react-egui-app/src/lib.rs
+++ b/crates/react-egui-app/src/lib.rs
@@ -8,6 +8,8 @@
 use react_egui::layout::{ContainerStyle, ItemStyle};
 use react_egui::{Cx, Store, View};
 
+pub mod a11y;
+
 /// The eframe storage key everything `use_persisted` holds is written under.
 const STORAGE_KEY: &str = "react_egui";
 

--- a/crates/react-egui-elements/src/widgets.rs
+++ b/crates/react-egui-elements/src/widgets.rs
@@ -14,17 +14,33 @@ use react_egui::layout::ItemStyle;
 use react_egui::prelude::*;
 
 /// A clickable button.
+///
+/// `label` is the name assistive technology reads. Pass it whenever the
+/// children do not say what the button does — an icon or a single glyph like
+/// `"x"` reads as that glyph and nothing more. It only renames the accessibility
+/// node; what is drawn stays the children.
 #[component]
 pub fn Button(
     cx: &mut Cx,
     #[prop(default)] style: ItemStyle,
     #[prop(default = true)] enabled: bool,
+    label: Option<&str>,
     #[event] on_click: (),
     children: impl Into<egui::WidgetText>,
 ) {
     let clicked = cx.leaf(&style, |ui| {
         let button = egui::Button::new(children).wrap_mode(egui::TextWrapMode::Extend);
-        ui.add_enabled(enabled, button).clicked()
+        let response = ui.add_enabled(enabled, button);
+        if let Some(label) = label {
+            // The widget has already written its node for this pass, so this
+            // overwrites the label egui took from the children.
+            // `Response::widget_info` would work too, but it pushes a second
+            // `OutputEvent` on the frame the button is clicked.
+            // Returns `None` when accesskit is off, which is the usual case.
+            ui.ctx()
+                .accesskit_node_builder(response.id, |node| node.set_label(label));
+        }
+        response.clicked()
     });
     if clicked {
         on_click.emit(());
@@ -202,17 +218,26 @@ pub fn ComboBox<S: AsRef<str>>(
 ///
 /// The loader for the source's scheme has to be installed by the application
 /// (`egui_extras::install_image_loaders`); this element only draws.
+///
+/// `alt` is the alternative text: it names the image for assistive technology
+/// and is drawn next to the ⚠ placeholder when the image fails to load. An
+/// image without `alt` has no name at all, so pass one unless the image is
+/// decoration.
 #[component]
 pub fn Image(
     cx: &mut Cx,
     #[prop(default)] style: ItemStyle,
     source: egui::ImageSource<'_>,
     fit: Option<egui::Vec2>,
+    alt: Option<&str>,
 ) {
     cx.leaf(&style, |ui| {
         let mut image = egui::Image::new(source);
         if let Some(size) = fit {
             image = image.fit_to_exact_size(size);
+        }
+        if let Some(alt) = alt {
+            image = image.alt_text(alt);
         }
         ui.add(image)
     });

--- a/crates/react-egui-elements/tests/widgets.rs
+++ b/crates/react-egui-elements/tests/widgets.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use common::run_app;
 use egui_kittest::Harness;
+use egui_kittest::kittest::NodeT as _;
 use egui_kittest::kittest::Queryable as _;
 use react_egui::prelude::*;
 use react_egui_elements::prelude::*;
@@ -259,6 +260,75 @@ fn image_draws_without_a_loader_installed() {
     // this checks is that the element compiles and draws egui's placeholder
     // instead of panicking.
     harness.run();
+}
+
+/// Plan a11y A-1: `alt` is the image's name in the accessibility tree, and an
+/// image without it has no name at all.
+#[test]
+fn image_alt_text_names_the_node() {
+    let mut harness = Harness::new_ui_state(
+        |ui, store: &mut Store| {
+            run_app(ui, store, |cx| {
+                rsx! {
+                    <Image
+                        source={egui::ImageSource::Uri("file://cat.png".into())}
+                        fit={egui::vec2(32.0, 32.0)}
+                        alt="a cat"
+                    />
+                    <Image
+                        source={egui::ImageSource::Uri("file://dog.png".into())}
+                        fit={egui::vec2(32.0, 32.0)}
+                    />
+                }
+                .show(cx);
+            });
+        },
+        Store::new(),
+    );
+
+    harness.run();
+    assert!(harness.query_by_label("a cat").is_some());
+    // Two images are drawn; only the one with `alt` carries a name.
+    let images: Vec<_> = harness
+        .query_all_by_role(egui::accesskit::Role::Image)
+        .collect();
+    assert_eq!(images.len(), 2);
+    let named: Vec<_> = images
+        .iter()
+        .filter_map(|node| node.accesskit_node().label())
+        .collect();
+    assert_eq!(named, ["a cat"]);
+}
+
+/// Plan a11y A-2: `label` renames an icon-only button for assistive technology
+/// without changing what is drawn.
+#[test]
+fn button_label_renames_the_node_only() {
+    let mut harness = Harness::new_ui_state(
+        |ui, store: &mut Store| {
+            run_app(ui, store, |cx| {
+                rsx! {
+                    <View direction="row" gap={8}>
+                        <Button label="delete" on_click={|| {}}>"x"</Button>
+                        <Button on_click={|| {}}>"x"</Button>
+                    </View>
+                }
+                .show(cx);
+            });
+        },
+        Store::new(),
+    );
+
+    harness.run();
+    let named = harness.get_by_role_and_label(egui::accesskit::Role::Button, "delete");
+    let named_rect = named.rect();
+
+    // The children still draw: the button is the same size as the unlabelled
+    // one next to it, which reads as "x".
+    let plain_rect = harness
+        .get_by_role_and_label(egui::accesskit::Role::Button, "x")
+        .rect();
+    assert_eq!(named_rect.size(), plain_rect.size());
 }
 
 /// A taffy leaf is measured from the size it reported the last time it was

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,7 @@ React 風の書き方(JSX、関数コンポーネント、hooks)で egui アプ�
 - JS / TS の React を動かすこと。JS ランタイムは同梱しない。
 - React の意味論への忠実な再現。VDOM、reconciler、`memo()`、`useCallback` は作らない。
 - Signal 風の細粒度反応性。購読機構は持たない。
+- web でのスクリーンリーダー対応。egui / AccessKit の web 対応に依存する。egui はウィジェットツリーを AccessKit に出しており、native では OS のアクセシビリティ API に届くが、web ではそれを DOM に映す adapter が上流に無い(`docs/tasks/a11y/`)。要素のラベル(`Button` の `label`、`Image` の `alt`)は adapter が入った日にそのまま効くので、先に埋めてある。
 
 ## 2. 基本原理
 
@@ -383,6 +384,7 @@ egui は 0.36 系に固定する。egui 0.35 以降 `eframe::App::ui` が `&mut 
 
 - native / wasm / Android: eframe。wasm は trunk でビルドする。描画バックエンドは wgpu。**eframe 0.36 の既定 feature には `wgpu` が入っていて `glow` は入っていない**(0.35 までとは逆)ので、何もしなくても wgpu で描かれる。glow の方が opt-in になったため、選択のための feature は置かない。web は WebGPU 非対応のブラウザのために WebGL へ落ちる。`eframe/wgpu` → `egui-wgpu/default` → `wgpu/webgl` と伝播するので、こちらで `wgpu` を直接依存に取る必要は無い。
 - iOS: eframe は未対応(emilk/egui#3117 が open)。`egui-winit` + `egui-wgpu` の薄いランナーを `react-egui-app` 内に書く。ビルドは cargo-mobile2。
+- アクセシビリティ: native は eframe(egui-winit)が `Context::enable_accesskit` を呼び、ウィジェットツリーが OS のアクセシビリティ API に届く。**web では届かない。** eframe の web ランナーは毎フレームの `TreeUpdate` を `accesskit_update: _, // not currently implemented`(`eframe/src/web/app_runner.rs`)と捨てており、canvas の中身を DOM に映す adapter も上流に無い。方針と試作は `docs/tasks/a11y/`。
 - ライブラリ本体は `&mut egui::Ui` しか触らないので、プラットフォーム対応はランナー層とタッチ / IME の調整に閉じる。
 - 非同期の実行機構は core の `task::spawn` に閉じる(4 章「`use_future` の詳細」)。iOS / Android は native と同じスレッド経路を使う。
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -323,10 +323,12 @@ Flexbox / Grid を一級市民にするため egui_taffy を採用する(0.14、
 | 種類 | 要素 |
 |---|---|
 | レイアウト | `View`(`display` / `direction` / `wrap` / `justify` / `align` / `align_content` / `gap` / `cols`)、`Text`(`size` / `color` / `strong` / `wrap`) |
-| ウィジェット | `Button`(`enabled`, `on_click`)、`Label`(`wrap`)、`TextEdit`(`bind` / `multiline` / `hint` / `desired_width` / `rows`, `on_change` / `on_submit`)、`Checkbox`(`bind` / `label`, `on_change`)、`Slider<T: Numeric>`(`bind` / `range` / `label`, `on_change`)、`ComboBox`(`bind` / `options` / `label`, `on_change`)、`Image`(`source` / `fit`)、`Separator`(`vertical`) |
+| ウィジェット | `Button`(`enabled` / `label`, `on_click`)、`Label`(`wrap`)、`TextEdit`(`bind` / `multiline` / `hint` / `desired_width` / `rows`, `on_change` / `on_submit`)、`Checkbox`(`bind` / `label`, `on_change`)、`Slider<T: Numeric>`(`bind` / `range` / `label`, `on_change`)、`ComboBox`(`bind` / `options` / `label`, `on_change`)、`Image`(`source` / `fit` / `alt`)、`Separator`(`vertical`) |
 | コンテナ | `ScrollArea`、`VirtualList`(`rows` / `row_h` / `render`)、`Collapsing`、`Frame`、`Window`(`title` / `open` / `resizable` / `default_pos` / `default_size`)、`Panel`(`side`)、`CentralPanel`、`Vertical`、`Horizontal`、`Grid` + `row()` |
 | 描画 | `Canvas`(`sense` / `paint`, `on_drag` / `on_hover`。taffy がくれた矩形をそのまま渡す leaf) |
 | 非同期 | `Suspense`(`fallback: impl View`、`shares_ui`。中の `use_future` が 1 つでも `Pending` なら children の代わりに `fallback` を描く。5.8) |
+
+`Button` の `label` と `Image` の `alt` は支援技術が読む名前である。`Button` の `label` は描くもの(children)を変えず、accesskit ノードの名前だけを差し替える(`Context::accesskit_node_builder`)。アイコンや `"x"` だけのボタンはそのままでは字面しか読まれないので渡す。`Image` の `alt` は `egui::Image::alt_text` に落ち、読み込みに失敗したときの ⚠ の隣にも描かれる。web での読み上げ自体は 1 章の非ゴールのとおり上流待ちだが、これらは native では今日から効く。
 
 `TextEdit` は taffy の中(`Cx::in_taffy()`)ではノードを埋める。単行は `desired_width` をノードの幅にし、`multiline` は `ui.add_sized(ui.available_size(), ..)` で縦横とも埋める(`desired_rows` だと行単位にしか合わず、端数がノードからはみ出す)。`grow` や `w` で広げたノードの中に egui 既定の 280pt / 4 行で描かれると残りが空くためである。`desired_width` / `rows` を明示した場合はそちらが勝つ。`Slider` / `ComboBox` / `Button` は今のところ伸びない(それぞれ `spacing.slider_width` / `spacing.combo_width` / 内容の幅のまま)。
 

--- a/docs/tasks/a11y/plan.md
+++ b/docs/tasks/a11y/plan.md
@@ -8,16 +8,19 @@
 
 **1 PR では終わらない。main に入るものと、`a11y-spike` ブランチに置くものに割る。** task.md の決めごと「react-egui の main に fork した eframe を依存として入れない」を守るためで、境界は「crates.io の依存だけで完結するか」に置く。
 
+**割り方は着手後に変わった。** 当初は手順 6 以降をまるごと `a11y-spike` に置く前提だったが、1.2 で「`TreeUpdate` を受け取るのに eframe の fork は要らない」(2.2 の案 C)ことが分かった。**手順 6〜10 は crates.io の依存だけで閉じるので main に入れる。** fork が要るのは手順 11(F2)だけで、そこだけが spike に残る。
+
 | | 場所 | 内容 |
 |---|---|---|
-| この PR | main | 本書、ARCHITECTURE 1 章 / 8 章の一文、README の一文、`react-egui-elements` のラベル固め(`Image` の `alt`、`Button` の `label`)、名前の無いウィジェットを検出する kittest |
-| 続き | `a11y-spike` ブランチ | `accesskit_web` の原型(adapter crate)、gallery を VoiceOver で触るための wasm ビルド、必要なら fork した eframe |
+| PR #4(済) | main | 本書、ARCHITECTURE 1 章 / 8 章の一文、README の一文、`react-egui-elements` のラベル固め(`Image` の `alt`、`Button` の `label`)、名前の無いウィジェットを検出する kittest |
+| PR #5(この続き) | main | `accesskit-web`(adapter crate)、`react_egui_app::a11y::WebA11y`(egui の plugin)、gallery での有効化、DOM → `ActionRequest`、フォーカス F1 |
+| 続き | `a11y-spike` ブランチ | 手順 11 だけ: fork した eframe で `has_focus` を緩める F2 |
 | その後 | 上流 | AccessKit へ web adapter の PR、eframe / egui へ差し込み口の issue |
 
 割り方の根拠は 2 つ。
 
 1. **ラベル固めは上流と無関係に効く。** native の VoiceOver / NVDA / Orca には今日から効き、web adapter が入った日にもそのまま効く。むしろ adapter が動いた瞬間に「名前の無いボタン」が全部露見するので、先に潰しておく方が試作が読みやすい。
-2. **試作は crates.io の依存だけでは閉じない可能性が残る**(2.3。フォーカスの往復で eframe に手を入れる必要が出うる)。閉じるなら main に入れてもよいが、それは動かしてみるまで分からない。分からないものを main の Cargo.toml に入れない。
+2. **fork が要るかどうかは 1 点に絞れた。** 当初は「試作は crates.io の依存だけでは閉じない可能性が残る」と書いたが、閉じないのは**フォーカスの往復だけ**である(2.3)。ツリーを受け取る側も `ActionRequest` を返す側も egui の `Plugin` で足りる。だから spike に残すのは F2 の 1 コミットで済む。
 
 ## 1. 調査結果
 
@@ -325,7 +328,7 @@ ARCHITECTURE / README に足す一文は次の趣旨。
 
 ## 3. 手順
 
-### この PR(main)
+### PR #4(main、済)
 
 1. **本書と task.md の訂正。** 1.1 で分かった `web-basics` ブランチの存在を task.md の背景表に反映する(「無い」→「リリース版は無い。試作ブランチが 1 本ある」)。コミット。
 2. **`Image` の `alt`、`Button` の `label`。** `crates/react-egui-elements/src/widgets.rs`。kittest を `tests/widgets.rs` に 2 本(A-1、A-2)。コミット。
@@ -333,16 +336,24 @@ ARCHITECTURE / README に足す一文は次の趣旨。
 4. **名前の無いノードを見つける kittest**(A-3)。gallery の全 example を 1 つずつ描き、focusable なノードに空でない名前があることを確かめる。コミット。
 5. **ARCHITECTURE 1 章 / 8 章と README の一文。** README は「Examples」節の gallery の段落(`Every example but one runs in the browser ..`)の末尾に足す。コミット。PR。
 
-### `a11y-spike` ブランチ(この PR の後)
+### PR #5(main、この続き)
 
-`main` から切る。fork した eframe を入れることになってもこのブランチに閉じる。
+0 章のとおり、ここは fork を必要としないので main に入れる。
 
-6. **`accesskit_web` の骨格を移植する。** `web-basics` の 4 ファイルを `crates/accesskit-web/`(spike のみ)に置き、accesskit 0.24.1 / consumer 0.38 に合わせて直す(`name()` → `label()`、`is_focusable(&filter)`、`TreeId`)。まだ座標もイベントも無い。ビルドが通ることだけ確かめる。
+6. **`accesskit_web` の骨格を移植する。** `web-basics` の 4 ファイルを `crates/accesskit-web/` に置き、accesskit 0.24.1 / consumer 0.38 に合わせて直す(`name()` → `label()`、`is_focusable(&filter)`、`TreeId`)。まだ座標もイベントも無い。ビルドが通ることだけ確かめる。
 7. **座標とホストの CSS**(2.1)。`bounding_box()` を `position: absolute` に落とし、canvas に重ねる。DevTools で矩形がウィジェットの上に乗っていることを目視。
 8. **`react_egui_app::a11y::WebA11y`(plugin)と `Options::setup` からの起動**(2.2)。gallery を trunk でビルドし、DOM が毎フレーム更新されることを目視。捨てられたパスを弾く条件がちゃんと効いているかを、taffy が 2 パス回る example(layout)で確かめる。
 9. **DOM → `ActionRequest`**(2.1 の表)。click と Enter / Space で counter の `+` が増えるところまで。
 10. **フォーカス F1**(2.3)。`aria-activedescendant` 版。VoiceOver(macOS Safari / Chrome)で counter / todo / form を触る。
+
+### `a11y-spike` ブランチ(PR #5 の後)
+
+`main` から切る。fork した eframe はこのブランチに閉じる。
+
 11. **F1 で足りなければ F2。** eframe を fork し、`has_focus` を「canvas の親の中に activeElement があるか」に緩める。`[patch.crates-io]` で git fork を指す。**このコミットは spike ブランチだけに置く。**
+
+### 上流
+
 12. **上流。** AccessKit に discussions#514 の続きとして「web-basics を現行 API に起こし、座標とイベントを足した。引き取れるか」を書く。eframe / egui に「web で AccessKit ツリーが捨てられている。adapter を eframe が持つ形を提案する」の issue を立てる。
 
 ## 4. テスト / 確認
@@ -359,7 +370,7 @@ kittest は AccessKit ツリーをそのまま歩く(`egui_kittest::Harness::roo
 
 A-3 は「今後 example を足した人が名前を忘れたら赤くなる」ための仕掛けなので、失敗メッセージに「`label` を渡してください」と書く。窓は既存の `examples/gallery/tests/gallery.rs` と同じ 1280×1000 にする(`ScrollArea` が描かなかったウィジェットはツリーにも居ないので、小さい窓だと見逃す)。
 
-### spike(手で確かめる)
+### web(手で確かめる)
 
 wasm の自動テストは `wasm-bindgen-test` で DOM の形(ノード数、`role`、`aria-label`、矩形)までは書けるが、**支援技術が実際にどう読むかは自動化できない**。VoiceOver の挙動が全てなので、チェックリストを置いて手で回す。
 
@@ -381,17 +392,17 @@ wasm の自動テストは `wasm-bindgen-test` で DOM の形(ノード数、`ro
 
 ## 5. 終了条件との対応
 
-task.md の終了条件は 3 つある。この PR で満たせるのは 3 番目だけで、残りは spike の後。
+task.md の終了条件は 3 つある。3 番目は PR #4 で済み、1 番目は手順 10(必要なら 11)、2 番目は手順 12。
 
 | 終了条件 | どこで |
 |---|---|
 | gallery(web)の counter / todo / form を VoiceOver で読み上げ・Tab・Enter / Space | 手順 10(必要なら 11)、4 章のチェックリスト |
 | 上流に web adapter と eframe の差し込み口の提案が出ている | 手順 12 |
-| ARCHITECTURE.md に web の a11y の現状と方針が書かれている | 手順 5(**この PR**) |
+| ARCHITECTURE.md に web の a11y の現状と方針が書かれている | 手順 5(**PR #4 で済**) |
 
 ## 6. 実装で判明した差分
 
-手順 2〜5(main に入るラベル固め)を実装したときに分かったこと。
+手順 2〜5(PR #4、ラベル固め)は 6.1〜6.5、手順 6〜9(PR #5、ミラー本体)は 6.6〜6.9。
 
 ### 6.1 `Button` の `label` は 3 章のとおり。`Image` の `alt` も同じ
 
@@ -428,3 +439,36 @@ counter と custom-hook のボタン。名前は空ではない(「プラス」�
 ### 6.5 A-3 は `run` ではなく `run_steps(2)`
 
 `shader`(と `clock`)は毎フレーム再描画を要求するので、`Harness::run` が「4 ステップで落ち着かない」と panic する。`fetch` は描いた瞬間に本物の HTTP を投げるので、既存の `gallery.rs` と同じ理由で外してある。
+
+### 6.6 手順 6: 移植で変わったところ
+
+- `accesskit_consumer` 0.38 でも `TreeChangeHandler` / `TreeState` は `ChangeHandler` / `State` の別名として残っていたので、そのまま使えた。変わるのは `HashMap` のキーで、`accesskit::NodeId` ではなく**木の index を含む consumer 側の `NodeId`** になる。
+- `Role::Directory` は accesskit 0.24 に無いので role 表から落とした。他の 150 行はそのまま通る。
+- `Adapter::new` は `-> Self` ではなく **`-> Option<Self>`**。`window()` / `document()` の `unwrap()` を wasm に持ち込まないため。親も id 文字列ではなく `&Element` で受ける(2.1 のとおり)。`set_attribute` の `unwrap()` も全部落とした(属性名は定数なので失敗しない)。
+- **`focus_moved` は空にした。** `element.focus()` は 1.3 の壁そのもので、`blur()` は 1.4 の教訓から呼ばない。egui → DOM のフォーカスは手順 10 の仕事。
+- root のホストに `role="application"` は付けていない(2.1 の保留どおり)。egui の root ノードが `role="window"` として 1 段下に出る。
+- **native でも `web-sys` はビルドが通る**ので、crate 全体を `cfg` で切らずに置いた。workspace の `clippy --all-targets` と `test` が accesskit-web も見る。
+- clippy の `large_enum_variant` に言われて `State::Active` の `Tree` は `Box` に入れた。
+
+### 6.7 手順 7: 座標
+
+- **子の `left/top` は親の矩形からの相対にする必要があった。** 絶対配置の親が絶対配置の子の包含ブロックになるので、`bounding_box()` をそのまま書くと入れ子のぶんだけ二重にずれる。矩形を持たない祖先は飛ばし、一番近い「矩形を持つ祖先」を原点にする。Flutter の `recomputeChildrenAdjustment` と同じ話で、2.1 に書き落としていた。
+- デバッグ表示は `Adapter::set_debug(bool)`。`filter: opacity(0%)` を外して緑の `outline` を出す。plugin 側は URL に `?a11y-debug` があれば on にする。
+- `tabindex` は `is_focusable(&filter)` が真なら `"0"`。ただしこれで Tab がミラーに入るようになるので、1.3 の壁に当たるのは手順 10 の宿題として残る。
+- `Role::Label` に `role="paragraph"` を明示した(1.4 の Safari のマージ対策)。
+- **`Role::Label` の文字は `label()` ではなく `value()` に入っている**(`Node::label_comes_from_value`。egui もそう書いている)。ブラウザで見るまで気付かず、ミラーの文字が全部空だった。同じ文字を `aria-valuetext` に重ねて出さないようにもした。
+
+### 6.8 手順 8: plugin
+
+- **捨てられるパスの判定は `requested_discard()` だけでは足りない。** `max_passes` を使い切った最後のパスでもフラグは立ったままで、そこで捨てると最終形が DOM に出ない。`Context::run` のループの抜け条件と同じ `requested_discard() && num_completed_passes < max_passes` にした。**`ctx.will_discard()` は使えない**: `end_pass` が viewport の output を `mem::take` した後に plugin が呼ばれるので、常に false になる。
+- `Options::setup` は `FnOnce` が 1 本なので、gallery では `shader::gpu::setup(cc)` と `add_plugin` を同じクロージャに並べた。
+- `accesskit` は `egui::accesskit`(egui の再エクスポート)を使う。版がずれようがない。`accesskit-web` は wasm32 の依存にだけ入れ、native の `WebA11y` は空の plugin にした。
+
+### 6.9 手順 9: DOM → `ActionRequest`
+
+- 要素ごとに listener を張らず、**ホスト 1 枚に張って委譲**した。要素には `data-accesskit-node` / `data-accesskit-tree` を書いておき、イベントはそこから親を辿って target を作る。ノード数ぶんのクロージャを持たずに済む。`focus` は bubble しないので `focusin` を使う。
+- `ActionHandler` は `Rc<RefCell<Box<dyn ActionHandler>>>` で listener と共有する。plugin 側の実装はキューに積むだけで、`input_hook` が `RawInput` に流す。
+- **`ctx.request_repaint()` が要る。** egui は必要なときしか描かないので、キューに積んだだけでは次のフレームが来ない。支援技術のクリックは egui にとって「何も起きていない」のと同じ。これが無いと押しても無反応で、実測するまで気付かなかった。
+- 2.1 の表のうち `input` / `change` は、ミラーが今 `<div>` なので実際には飛んでこない(本物の `<input>` にしたときのため)。チェックボックスの toggle は合成 `click` の方で届く。
+- **headless Chrome での実測**(gallery、`?a11y-debug`): ミラーの button を `click()` すると example が切り替わり、counter の `+` で数が増える。`keydown` の Enter / Space も効く。`elementFromPoint` はミラーではなく canvas を返す(`pointer-events: none` が効いている)。
+- `crates/accesskit-web/tests/mirror.rs` は `#![cfg(target_arch = "wasm32")]` で囲ってあるので `cargo test --workspace` は素通りする。`wasm-pack test --headless --chrome crates/accesskit-web` で 4 本通る。

--- a/docs/tasks/a11y/plan.md
+++ b/docs/tasks/a11y/plan.md
@@ -519,3 +519,7 @@ counter と custom-hook のボタン。名前は空ではない(「プラス」�
 - `Role::MultilineTextInput` は `<div role="textbox">` のまま。`<textarea>` にするかは、テキスト欄の読み上げを一度見てから決める。
 - form の slider の隣に出る `SpinButton`(egui の `DragValue`)は `step` がドラッグの刻み(1.12…)になる。矢印キーで動かす分には粗すぎるので、`numeric_value_step` を使うかどうかは role ごとに分ける余地がある。
 - `aria-owns` はミラーを canvas の下に付け替えるので、canvas 自身の子(将来 eframe が何か置いたら)との順序は保証しない。
+
+### 手順 12: 上流化はしない
+
+2026-09-05 の判断で取り下げ。AccessKit(discussions#514)にも eframe にも出さない。`crates/accesskit-web` と `react_egui_app::a11y::WebA11y` は react-egui の一部として保守する。上流が同等のものを出したら乗り換える。

--- a/docs/tasks/a11y/plan.md
+++ b/docs/tasks/a11y/plan.md
@@ -1,0 +1,392 @@
+# プラン: a11y(web のアクセシビリティ)
+
+タスク定義は [task.md](task.md)。設計の根拠は [docs/ARCHITECTURE.md](../../ARCHITECTURE.md)。本書は調査の結果と、そこから決めた作業手順を定める。実装中にここから外れる判断をした場合は本書を更新し、設計上の意味があれば ARCHITECTURE.md も更新する。
+
+調査は 2026-09 に行った。対象は egui / eframe 0.36.1、accesskit 0.24.1、accesskit_consumer 0.38.0(このリポジトリの `Cargo.lock` が引いている版。上流の最新は accesskit 0.25.0 / consumer 0.39.0、2026-08-29 リリース)。
+
+## 0. 全体
+
+**1 PR では終わらない。main に入るものと、`a11y-spike` ブランチに置くものに割る。** task.md の決めごと「react-egui の main に fork した eframe を依存として入れない」を守るためで、境界は「crates.io の依存だけで完結するか」に置く。
+
+| | 場所 | 内容 |
+|---|---|---|
+| この PR | main | 本書、ARCHITECTURE 1 章 / 8 章の一文、README の一文、`react-egui-elements` のラベル固め(`Image` の `alt`、`Button` の `label`)、名前の無いウィジェットを検出する kittest |
+| 続き | `a11y-spike` ブランチ | `accesskit_web` の原型(adapter crate)、gallery を VoiceOver で触るための wasm ビルド、必要なら fork した eframe |
+| その後 | 上流 | AccessKit へ web adapter の PR、eframe / egui へ差し込み口の issue |
+
+割り方の根拠は 2 つ。
+
+1. **ラベル固めは上流と無関係に効く。** native の VoiceOver / NVDA / Orca には今日から効き、web adapter が入った日にもそのまま効く。むしろ adapter が動いた瞬間に「名前の無いボタン」が全部露見するので、先に潰しておく方が試作が読みやすい。
+2. **試作は crates.io の依存だけでは閉じない可能性が残る**(2.3。フォーカスの往復で eframe に手を入れる必要が出うる)。閉じるなら main に入れてもよいが、それは動かしてみるまで分からない。分からないものを main の Cargo.toml に入れない。
+
+## 1. 調査結果
+
+### 1.1 AccessKit の web adapter: 試作が 1 本あり、フォーカスで止まっている
+
+task.md の背景表は「AccessKit に web adapter が存在しない」と書いたが、**正確には「リリースされていないが、ブランチに 500 行ほどの試作がある」**。
+
+- 議論: [AccessKit/accesskit discussions#514 "Web Adapter"](https://github.com/AccessKit/accesskit/discussions/514)(2025-02)。外部の人(floers)が「web adapter を書きたいが重複作業か」と聞き、メンテナ(DataTriny)が「[`web-basics` ブランチ](https://github.com/AccessKit/accesskit/tree/web-basics)にすでにある。かなり動くが数ヶ月触っていない。引き継ぐ気はあるか」と答えた。
+- **その後が本題。** floers が 2025-03 にこのブランチを土台に **Slint の web デモ**を作り([floers/accesskit の `web-basics`](https://github.com/floers/accesskit/tree/web-basics)、`examples/slint-web`)、DOM のボタンを押すと Slint 側が反応するところまで動かした。**逆方向の作り方も同じ結論に達している**: 「`action_handler` は実装するものではなく、**使って** action を送るものだった。DOM のボタンに JS の `on_click` を付けて `action_handler` 経由で投げたら動いた」。
+- **そしてメンテナの検証(2025-03-09)がこう終わっている。** 「試したが **as-is ではスクリーンリーダーで使えない。フォーカスの移動が信頼できない**(Slint 側の問題かもしれないが)。デモとしては良い」。以降このスレッドは止まっている。**1.3 で我々が独立に見つけた壁と同じ場所**である。
+- ブランチの最終コミットは `51dbebd`(2024-07-15、"Set application role on the root node")。中身は `platforms/web/` に `Cargo.toml`(crate 名 `accesskit_web` 0.1.0)、`src/lib.rs` / `adapter.rs`(6.6 KB)/ `node.rs`(11.3 KB)/ `filters.rs`。AccessKit の README の「Planned adapters」に web が挙がっている。
+- **crates.io に `accesskit_web` は無い**(`https://crates.io/api/v1/crates/accesskit_web` が 404)。リリースの一覧にも web は無く、直近の 2026-08-29 のリリース波は common / consumer / windows / macos / unix / android / **ios** / winit で、iOS adapter([issue#565](https://github.com/AccessKit/accesskit/issues/565))は `accesskit_ios` 0.2.0 として出ている。web だけが空いている。
+- リポジトリ全体を「web」「DOM」「wasm」「browser」で検索した限り、他に web adapter の議論は無い。DOM 関連で出てくるのは[issue#705 "Add a property to allow exposing DOM ID"](https://github.com/AccessKit/accesskit/issues/705) → [PR#776 `html_id` node property](https://github.com/AccessKit/accesskit/pull/776)(2026-08-25 merge)だが、これは **Servo が AccessKit を「web コンテンツ → OS」の向きで使う**([servo/servo#4344](https://github.com/servo/servo/issues/4344))ための話で、向きが逆である。
+
+`web-basics` の中身を読むと、**骨格はそのまま使えるが、動くところまでは行っていない**。
+
+| ある | 無い |
+|---|---|
+| `Adapter::new(parent_id, ActivationHandler, ActionHandler)`、`update_if_active(impl FnOnce() -> TreeUpdate)`、`update_host_focus_state(bool)` | **座標**。ノードは入れ子の `<div>` を作るだけで、`bounding_box()` を読んでおらず、`position: absolute` も CSS も一切無い。canvas に重ならない |
+| `Tree` / `TreeChangeHandler`(`node_added` / `node_updated` / `focus_moved` / `node_removed`)で差分だけ DOM に反映 | **DOM → egui の経路**。`action_handler` を持つだけで、**一度も呼んでいない**。click も keydown も listener が無い |
+| `Role` → ARIA role の対応表(約 150 行、`CheckBox`→`checkbox`、`TextInput`→`textbox`、`Slider`→`slider`、…) | Tab で辿れる順序。`tabindex` は focusable なら `"-1"` 固定 |
+| `aria-label` / `aria-checked` / `aria-valuemin` / `aria-valuemax` / `aria-valuenow` / `aria-valuetext`、`Role::Label` だけ `textContent` | `aria-expanded` / `aria-selected` / live region / テキスト選択 / スクロール |
+| `focus_moved` で `element.focus()` / `blur()` | DOM 側でフォーカスが動いた時に egui へ返す経路 |
+
+さらに **API が 2 年ぶんずれている**。`Node::name()` は `label()` に、`is_focusable()` は `is_focusable(&parent_filter)` に変わり、accesskit 0.24 で複数ツリー対応([PR#655](https://github.com/AccessKit/accesskit/pull/655))が入って `TreeUpdate` に `tree_id`、`ActionRequest` に `target_tree` が増えた。ブランチが依存しているのは accesskit 0.16 / consumer 0.24 なので、そのままはビルドしない。
+
+**結論: ゼロからではなく、この 500 行を現行 API に移植し、抜けている「座標」「DOM → egui」「Tab 順」を足すのが最短路。** 上流に持ち込むときも「あなたのブランチを起こしました」という形になるので、話が早い。そして **web adapter が止まっている理由は「フォーカス」の 1 点**だとメンテナ自身が書いているので、試作が出す価値のある答えもそこにある(1.3、2.3)。「ツリーは映る。フォーカスがこの形なら通る/通らない」を実測して返すのが、この試作の一番の成果になる。
+
+なお、`Cargo.lock` には consumer が 0.35 / 0.36 / 0.38 の 3 つ入っている(kittest 0.4 が 0.35、accesskit_windows が 0.35、atspi が 0.36、accesskit_macos が 0.38)。すべて accesskit 0.24.1 に対して動いているので、**試作の adapter も `accesskit = "0.24.1"` + `accesskit_consumer = "0.38"` で組める**(macos adapter と同じ組み合わせ)。egui が握る `TreeUpdate` と型が一致することが条件なので、`accesskit` の版だけは egui に合わせる。
+
+### 1.2 eframe 0.36 web: ツリーは確かに捨てられているが、fork 無しで拾える
+
+`crates/eframe/src/web/app_runner.rs` の 394 行目、`handle_platform_output` の分解パターンに `accesskit_update: _, // not currently implemented` がある(手元の `~/.cargo/registry/.../eframe-0.36.1/src/web/app_runner.rs:394`)。ここは task.md のとおり。ただし調べた結果、**周辺の前提が 3 つ違っていた。**
+
+**(a) `accesskit` は egui の feature ではない。** eframe の `accesskit` feature は `["egui-winit/accesskit"]` だけで、native 専用である。egui 本体は `accesskit = "0.24.1"` を**無条件の依存**として持ち、`Context::enable_accesskit()` / `disable_accesskit()` / `accesskit_node_builder()` はいつでも呼べる(`egui-0.36.1/src/context.rs:3698`)。**wasm でも `ctx.enable_accesskit()` を呼べばその場でツリーが作られ始める。** 呼ぶ主体が居ないだけで、機能は生きている。呼ぶのはアプリでよく、`react_egui_app::Options::setup` の `&CreationContext` から `cc.egui_ctx.enable_accesskit()` と書ける。
+
+**(b) egui 0.36 には `Plugin` trait があり、`FullOutput` を横から掴める。** `egui::plugin::Plugin`(`egui-0.36.1/src/plugin.rs`)は次を持つ。
+
+```rust
+pub trait Plugin: Send + Sync + std::any::Any + 'static {
+    fn debug_name(&self) -> &'static str;
+    fn setup(&mut self, ctx: &Context) {}
+    fn on_begin_pass(&mut self, ui: &mut Ui) {}
+    fn on_end_pass(&mut self, ui: &mut Ui) {}
+    fn input_hook(&mut self, ctx: &Context, input: &mut RawInput) {}
+    fn output_hook(&mut self, ctx: &Context, output: &mut FullOutput) {}   // ← ここ
+}
+```
+
+`Context::end_pass()` の最後で `plugins.on_output(self, &mut output)` が呼ばれ(`context.rs:2440` 付近)、その時点で `platform_output.accesskit_update` はすでに埋まっている(埋めるのは `ContextImpl::end_pass`、`context.rs:2692` 付近)。登録は `Context::add_plugin(impl Plugin)` で public。
+
+つまり **`TreeUpdate` を受け取るのに eframe を fork する必要は無い。** 逆向き(`ActionRequest` の注入)も `Plugin::input_hook(&mut RawInput)` で足りる。eframe 側にも `App::raw_input_hook(&Context, &mut RawInput)` という public な穴がある(`eframe-0.36.1/src/epi.rs:279`)が、plugin の方が eframe に依存せず、kittest でもそのまま動くので好ましい。
+
+注意が 2 つ。
+
+- `Plugin` は `Send + Sync` を要求するが、`web_sys::HtmlElement` などは `!Send`。**DOM 側の状態は `thread_local!` のレジストリに置き、plugin 構造体は整数のキーだけを持つ**形にする(wasm は単スレッドなので `unsafe impl Send` を書く必要も無い)。
+- `output_hook` は**パスごとに**呼ばれる。egui は `request_discard` されたパスをやり直すので(`context.rs:833` の `loop`)、react-egui では taffy が普通に 2 パス回る(ARCHITECTURE 5.3)。`output.platform_output.requested_discard()` が立っているパスの `TreeUpdate` は**捨てる**。捨てたパスのツリーを DOM に流すと、レイアウトが決まる前の座標が一瞬出る。
+
+**(c) web 側に流用できる「隠し DOM」は screen reader 経路ではなく text agent。** `web_screen_reader` feature(既定 on)の実体は `web/screen_reader.rs` の `speak(text)` だけで、`speechSynthesis` に `platform_output.events_description()` の 1 行を投げる。ツリーもフォーカスも無い。流用価値は無い。
+
+代わりに参考になり、かつ**衝突する**のが `web/text_agent.rs` である。IME とモバイルキーボードのために、透明な `<input>` を canvas の兄弟として `position: absolute` で canvas の左上に置いている。DOM ミラーがやりたいことの縮小版がすでにそこにある。
+
+### 1.3 eframe web のフォーカスは canvas に固定されている(ここが唯一の本当の壁)
+
+`AppRunner::has_focus()` は「canvas か text agent が `document.activeElement` か」で、それ以外の要素にフォーカスがあると **`false`** を返す(`app_runner.rs:227`、`web/mod.rs:77` の `has_focus`)。そして `logic()` の頭で `update_focus()` が `input.raw.focused = false` を立てる。さらに `handle_platform_output` は、アプリにフォーカスがある間、毎フレーム `focus_without_scroll(self.canvas())` を呼んで canvas にフォーカスを引き戻す。
+
+つまり **ミラーの `<div>` に `element.focus()` すると、egui は「自分はフォーカスを失った」と判断してキー入力を受け付けなくなる。** `web-basics` の adapter がやっている `focus_moved` → `element.focus()` を eframe の上でそのまま動かすと、ここで壊れる。
+
+逃げ道は 2 つある。
+
+| | やり方 | 代償 |
+|---|---|---|
+| F1 | DOM フォーカスは canvas に置いたまま、canvas に `aria-activedescendant` で「今どのノードに居るか」を伝える | fork 不要。ただし `aria-activedescendant` の支援技術対応は role が限られ、VoiceOver では読み上げが落ちることが知られている。Tab キーは canvas 1 個しか止まらない |
+| F2 | ミラーの要素に本物のフォーカスを渡し、eframe の `has_focus` を「canvas の親コンテナの中に activeElement があるか」に緩める | **eframe の fork が要る**(数行)。支援技術の挙動は素直 |
+
+**Flutter は F2 側(本物の DOM フォーカス + `tabindex="0"`)を採っていて、`aria-activedescendant` は使っていない**(1.4)。前例に従うなら F2 が本命で、F1 は「fork せずにどこまで行けるか」を測るための当て馬である。**まず F1 で組んで VoiceOver で確かめ、駄目なら F2 に落ちる。** そして F2 が必要だったことがそのまま「eframe への上流提案」の中身になる。上流に出す形は「`WebOptions` に `accesskit` の口を開ける」ではなく、**eframe が adapter を持つ**のが本筋である。eframe は canvas も text agent もフォーカスも持っているので、外から差し込むより eframe の中に置いた方が短く済む。差し込み口を提案する場合でも、`has_focus` の緩和が一緒に要ることを添える。
+
+### 1.4 Flutter web の semantics 層
+
+同じ方式(canvas 描画 + DOM の鏡写し)を本番で回している唯一の前例。engine 統合後の現在地は [`engine/src/flutter/lib/web_ui/lib/src/engine/semantics/`](https://github.com/flutter/flutter/tree/master/engine/src/flutter/lib/web_ui/lib/src/engine/semantics)。**28 ファイル、約 280 KB の Dart**(`semantics.dart` だけで 3,490 行)。role ごとにファイルが割れている: `checkable.dart` / `focusable.dart` / `incrementable.dart` / `label_and_value.dart`(24 KB)/ `link.dart` / `live_region.dart` / `menus.dart` / `route.dart` / `scrollable.dart` / `table.dart` / `tabs.dart` / `tappable.dart` / `text_field.dart`(17 KB)/ `platform_view.dart` など。task.md の見積り「実用は数千行」はこの規模のことで、当たっている。
+
+**DOM の形**(`semantics.dart` と [`view_embedder/dom_manager.dart`](https://github.com/flutter/flutter/blob/master/engine/src/flutter/lib/web_ui/lib/src/engine/view_embedder/dom_manager.dart))。
+
+```
+<flutter-view>
+  <flt-glass-pane> -> #shadow-root { <flt-semantics-placeholder>, <flt-scene-host><flt-scene>(canvas) }
+  <flt-text-editing-host>
+  <flt-semantics-host>     ← 最後に append する。「ヒットテストの順では最初に来る必要があるため」
+```
+
+- **ミラーは canvas の兄弟で、DOM の最後**。eframe の text agent が canvas の兄弟に置かれているのと同じ位置取りで、`<flt-text-editing-host>` が別にあるのもそっくりである。
+- ノード 1 つに `<flt-semantics id="flt-semantic-node-N">` 1 つ(`SemanticRole.createElement`、724 行)。`position: absolute` + `overflow: visible`(`_initElement`、727 行)、大きさは矩形の px、位置は `transform-origin: 0 0 0` + CSS `transform` の行列。子は親の矩形とスクロール量を引いた相対座標にする(`recomputePositionAndSize` / `recomputeChildrenAdjustment`)。
+- **ホストが DPR を吸収する。** `<flt-semantics-host>` に `position:absolute; left:0; top:0; transform-origin:0 0 0; transform: scale(1/devicePixelRatio)`。コメントいわく「フレームワークは semantics を物理 px で出すが、CSS は論理 px を使う」。**2.1 でも同じ手を使う**(egui のツリーも root に `Affine::scale(pixels_per_point)` が乗っているので、ホスト 1 枚で割り戻せて、ノードごとの割り算が要らない)。
+- **透明にする方法が学べる。** **root ノードだけ**に `filter: opacity(0%)` と `color: rgba(0,0,0,0)`。コメントに理由が書いてある: 「`opacity` 属性ではなく `filter` を使う。`filter` の方が強く、iOS のスライダーの thumb / track のように `opacity` が効かない要素があるため」「`visibility: hidden` / `display: none` ではなく透明化を使う。スクリーンリーダーがこれらの要素を無視しないようにするため」。**2.1 のホストの CSS はこれに倣う。**
+- **本物の要素を使うところは使う。** link → `<a href>`、heading → `<h1>`〜`<h6>`(margin / padding 0、font-size 10px)、form → `<form>`、テキスト欄 → 子の `<input>` / `<textarea>`、スライダー → 子の `<input type=range role=slider>`。一方 **checkbox / radio / switch は本物の `<input>` にせず** `role` + `aria-checked` で作る。「全部 div」でも「全部本物」でもない。
+- **`role="application"` はどこにも無い**(リポジトリ全体で 0 件)。`web-basics` が root に付けていたのとは逆の判断である。
+- ラベルの出し方が 3 通りある(`label_and_value.dart` の `LabelRepresentation`)。`ariaLabel`(最も安いが「大半の web クローラと Windows の JAWS に効かない」)/ `domText`(テキストノード。button / link / heading)/ `sizedSpan`(CSS transform で実寸に伸ばした `<span>`。スクリーンリーダーのフォーカス枠がウィジェットの矩形と一致する。最も高い)。**`aria-label` 一本槍では駄目**というのがここの教訓。
+- `pointer-events` は 3 段階(`acceptsPointerEvents`、684 行)。`all` = 対話的か `SemanticsHitTestBehavior.opaque` / `none` = `transparent` か子を持つコンテナ / `auto` = `defer` の非対話的な葉(重なりの解決をブラウザの z-index に任せる)。子が 2 つ以上あるときはヒットテスト順を z-index の反転で作る(DOM の並び順は読み上げの順に使うので、2 つの順序を別々に持っている)。
+- 読み上げの通知は `aria-live` をノードに付けず、`document.body` 直下の `<flt-announcement-host>`(polite / assertive)に集約する。egui#2647(live region)を web でやるときに要る形。
+- デバッグ時は `debugShowSemanticsNodes` で緑の `outline` を引く(`border` はレイアウトを動かすので使わない)。試作でも同じ仕掛けを最初に入れると早い。
+
+**フォーカスとイベントの往復**(`focusable.dart` / `tappable.dart` / `pointer_binding.dart`)。ここが 1.1 の「フォーカスが信頼できない」の実際の対処なので、そのまま真似する価値がある。
+
+- **framework → DOM**: `changeFocus()` は `focusWithoutScroll()` を**更新後のコールバックまで遅らせる**。そして **`blur()` は決して呼ばない**(「要素を blur するのは非常に間違えやすい」)。同じ値の再設定も `_lastSetValue` で握り潰す。**`web-basics` の `focus_moved` は `blur()` を呼んでいる**(1.1 の表)ので、ここは移植時に落とす。
+- **DOM → framework**: `tabindex="0"` + `focus` / `blur` の listener で `SemanticsAction.focus` を送るが、**直前に自分が要求したフォーカスなら送らない**(`_lastEvent == requestedFocus`)。エコーの無限ループ止めである。
+- **クリック**: `ClickDebouncer` が `pointerdown` からイベントを溜め、200ms で流すか `click` が来たら `tap` に変える(「スクリーンリーダーは 200ms よりずっと速くクリックを合成する」)。50ms 以内に流した直後の `click` は捨てる。**合成クリックと本物のポインタ操作を見分けるための時間窓**で、これが無いと二重発火する(#130162)。
+- **スクロール**: `role=group` + DOM の `scroll` イベント → `SemanticsAction.scrollToOffset`。オーバーフローする子を 1 枚入れてスクロール範囲を偽装する。
+- **ルート遷移**: 「web のスクリーンリーダーはやってくれない」ので、engine が自分で最初の focusable な子孫にフォーカスする。
+
+**有効化**(`semantics_helper.dart`)。既定では semantics 層を作らず、支援技術が居ることを検出してから作る。作りっぱなしは重いため。
+
+- デスクトップ(`DesktopSemanticsEnabler`): `<flt-semantics-placeholder role="button" aria-live="polite" tabindex="0" aria-label="Enable accessibility">` を `position:absolute; left:-1px; top:-1px; width:1px; height:1px` で窓の外に置き、**クリックされたら** semantics を有効にする。「Tab で入っただけでは有効にしない。実際にクリックさせる」とコメントにある。
+- モバイル(`MobileSemanticsEnabler`): 同じ placeholder を画面全面に広げ、**クリック座標が placeholder のちょうど真ん中なら「スクリーンリーダーが送ったクリックだ」と解釈する**(331 行)というヒューリスティックで有効化する。
+- **placeholder は 2026 現在も健在**で、既定 off のままである([docs.flutter.dev の web accessibility](https://docs.flutter.dev/ui/accessibility/web-accessibility): 「性能上の理由で web のアクセシビリティは既定では on になっていない。有効にするにはユーザーが `aria-label="Enable accessibility"` の見えないボタンを押す必要がある」)。スクリーンリーダーの自動検出は**入っていない**。アプリから明示的に有効化する `SemanticsBinding.instance.ensureSemantics()` が逃げ道。
+- Flutter 3.32(2025-05)で semantics の構築が約 80% 速くなり web のフレーム時間が約 30% 縮んだが、**既定 on にはまだ届いていない**。「ミラーは重い」は今も事実である。
+
+**既知の弱点。**「Flutter web も解けていない」の中身は、そのまま我々が踏む穴でもある。
+
+| | 内容 |
+|---|---|
+| フォーカスリングが見えない | ミラーが透明なので、フォーカスされているノードが視覚的に分からない([#186044](https://github.com/flutter/flutter/issues/186044)、open) |
+| ミラーがマウスを食う | `ensureSemantics()` を呼ぶと `GestureDetector` の `Tap*Details` が壊れる([#188859](https://github.com/flutter/flutter/issues/188859))、モバイル web で semantics の onTap が背後の要素も叩く([#160560](https://github.com/flutter/flutter/issues/160560)) |
+| ブラウザがノードを勝手に潰す | role の無い素のテキストノードを Safari が暗黙にマージする([#166787](https://github.com/flutter/flutter/issues/166787)) |
+| Tab の順序 | iframe 埋め込みで自然な順にならない([#162871](https://github.com/flutter/flutter/issues/162871)) |
+| テキスト欄 | `excludeSemantics` が `<input>` の `aria-label` を壊す([#172206](https://github.com/flutter/flutter/issues/172206))。TextField 周りが 17 KB ある理由 |
+| ページ内検索 | Ctrl+F で本文を探せない([#65504](https://github.com/flutter/flutter/issues/65504)、2020 年から open)。原因が明快で、**「遅延描画のため engine は今見えている一部の UI しか知らない」「レイヤやピクチャからウィジェットへ戻る線が無い」**。egui も同じ(むしろ immediate mode なので徹底している) |
+| 翻訳 | ページ翻訳が効かない([#131984](https://github.com/flutter/flutter/issues/131984)) |
+| SEO | インデックスされない([#46789](https://github.com/flutter/flutter/issues/46789)、2020 年から open)。a11y が前提条件として挙げられている |
+| 性能 | ミラーの構築とスクロール時の再配置が重い(#163204、#159358)。3.32 の改善後も既定 on にできていない |
+
+ページ内検索 / 翻訳 / SEO は task.md が最初から「含まない」に置いたもので、その判断は正しかったことが確認できた。**「有効にするとアプリの挙動が壊れる」種類のバグが多いこと**も、この方式の性格として覚えておく価値がある(タップの二重発火 #147050 / #153924、重なった要素を突き抜ける #163576、入力できない #129324、ダイアログが勝手に閉じる #149001)。
+
+### 1.5 他の canvas 描画 UI
+
+| | a11y の扱い |
+|---|---|
+| Google Docs(2021 に DOM 描画から canvas に[移行](https://workspaceupdates.googleblog.com/2021/05/Google-Docs-Canvas-Based-Rendering-Update.html)) | canvas の兄弟に**見えない SVG のオーバーレイ**を置き、`<rect aria-label="..." x y width height transform>` を文字の上に並べる(いわゆる "annotated canvas")。既定 off で、許可された拡張が `window['_docs_annotate_canvas_by_ext']` を立てたときだけ出る([Chromium の `gdocs_script.js`](https://chromium.googlesource.com/chromium/src/+/main/chrome/browser/resources/chromeos/accessibility/common/gdocs_script.js))。サードパーティのスクリーンリーダー向けには**別の画面外 DOM** をユーザー設定で出す。**形は違うが「canvas + 座標付きの見えない DOM」という骨格は Flutter と同じ** |
+| makepad | web ランナーの `CxOsOp::AccessibilityUpdate(_) => {}` が**空**(`platform/src/os/web/web.rs`)。[makepad#196 "On Accessibility"](https://github.com/makepad/makepad/issues/196) が 2023 年から open |
+| Bevy | `bevy_a11y` が AccessKit ツリーを作るところまでは web でも動くが、渡す先の `accesskit_winit` が **wasm32 では何もしない adapter** なので web には出ない。まさに egui と同じ形 |
+| Slint | 公式ドキュメントが「web ではスクリーンリーダーなどのアクセシビリティ機能は使えない」と[明記](https://docs.slint.dev/latest/docs/slint/guide/platforms/web/)。1.1 の floers の試作は Slint で作られたもので、**この穴を埋めようとして止まった** |
+| iced | web の a11y は無い。[iced#552](https://github.com/iced-rs/iced/issues/552) が 2020 年から open で、途中の PR も native 向け |
+| Dioxus | web で本物の DOM を描くのでこの問題自体が無い(task.md が「それをやるなら Dioxus」と書いたとおり) |
+| HTML の canvas fallback content | `<canvas>` の子要素を代替として読ませる仕様([HTML Standard 4.12.5](https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element))と `drawFocusIfNeeded()`([4.12.5.1.14](https://html.spec.whatwg.org/multipage/canvas.html#drawing-focus-rings-and-scrolling-paths-into-view))。**足りない**。fallback 要素はボックスを持たないので**位置が無く**、拡大鏡や点字ディスプレイのルーティングが働かない。座標を扱うはずだった `addHitRegion` は 2016 年に、`scrollPathIntoView` は 2024 年に「どのブラウザも実装しなかった」として仕様から削除された。Chromium の canvas 担当者自身が [whatwg/html#7490](https://github.com/whatwg/html/issues/7490#issuecomment-1039495724) で「canvas で対話的な UI を描くアプリの多くは(Google Sheets のセル格子など)**fallback ではない見えない DOM 要素**でアクセシビリティを実装している」と書いている。MDN も「canvas の内容はアクセシビリティツールに公開されない。一般に canvas は避けるべき」と書く。将来の解は [WICG の HTML-in-Canvas](https://github.com/WICG/html-in-canvas) |
+
+**結論: 前例は Flutter web と Google Docs の 2 つで、どちらも「canvas + 座標を持つ見えない DOM」に行き着いている。標準の canvas fallback は当てにならないことも、仕様の削除履歴と実装者の発言で裏が取れた。** Rust 側は egui / Bevy / Slint / iced / makepad が揃って同じ場所で止まっており(AccessKit ツリーは作れる、web に出す adapter が無い)、**web adapter が 1 つ入れば全部が一度に動く**。上流に出す価値はそこにある。
+
+### 1.6 egui / eframe 側の関連 issue
+
+| | 内容 |
+|---|---|
+| [emilk/egui#167](https://github.com/emilk/egui/issues/167) | 元の a11y 要望。closed。AccessKit 導入([PR#2294](https://github.com/emilk/egui/pull/2294))で閉じた |
+| [emilk/egui#2391](https://github.com/emilk/egui/issues/2391) | README の a11y の記述を直す。「web を含む AccessKit 未対応のプラットフォームには実験的な内蔵スクリーンリーダーがある」という文面が提案され、closed |
+| [emilk/egui#2647](https://github.com/emilk/egui/issues/2647) | live region を出したい。**open**。web でも native でも要る |
+| [emilk/egui#7679](https://github.com/emilk/egui/pull/7679) | アプリが `Ui` の下に自前の AccessKit サブツリーを組めるようにする RFC。closed / 未 merge |
+| [emilk/egui#8410](https://github.com/emilk/egui/pull/8410) | root 以外の viewport にも adapter を付ける。open |
+
+web の a11y そのものを扱う issue は **egui にも eframe にも無い**。`accesskit_update: _` のコメントが唯一の記録である。上流に出す issue は新規になる。
+
+## 2. 設計
+
+### 2.1 `accesskit_web`(adapter crate、egui 非依存)
+
+task.md の決めごとどおり、AccessKit の `TreeUpdate` しか見ない。egui も eframe も知らない。`web-basics` の構成をそのまま引き継ぐ。
+
+```
+accesskit_web/
+  src/lib.rs      pub use adapter::Adapter
+  src/adapter.rs  Adapter: State { Pending | Active { tree, host, elements } }
+  src/node.rs     NodeWrapper: Role -> ARIA role、属性、座標
+  src/filters.rs  accesskit_consumer::common_filter
+```
+
+```rust
+pub struct Adapter { /* .. */ }
+
+impl Adapter {
+    /// `parent` の下に隠しホストを作る。canvas と同じ containing block に置く。
+    pub fn new(
+        parent: &web_sys::Element,
+        activation_handler: impl ActivationHandler,
+        action_handler: impl 'static + ActionHandler,
+    ) -> Self;
+
+    /// 1 フレーム 1 回。捨てられたパスでは呼ばない。
+    pub fn update_if_active(&mut self, update: impl FnOnce() -> TreeUpdate);
+
+    /// ホスト(canvas)がフォーカスを持っているか。
+    pub fn update_host_focus_state(&mut self, is_focused: bool);
+
+    /// ミラーを canvas の位置とスケールに合わせる。
+    pub fn set_viewport(&mut self, offset: (f64, f64), pixels_per_point: f64);
+}
+```
+
+`web-basics` から変える点。
+
+- **座標を入れる。** `Node::bounding_box()`(consumer 0.38、`node.rs:315`)を読み、`position: absolute` + `left/top/width/height` を px で書く。egui のツリーは root ノードに `Affine::scale(pixels_per_point)` が乗っているので(`egui/src/context.rs:525`)、`bounding_box()` は物理 px で出てくる。**ノードごとに割り算せず、ホストに `transform: scale(1/pixels_per_point)` を一度掛けて論理 px に戻す**(Flutter が `<flt-semantics-host>` でやっているのと同じ、1.4)。
+- **ホストの CSS は Flutter に倣う**(1.4)。`position: absolute` + canvas と同じ矩形、子は `position: absolute` + `overflow: visible`。透明化は **`filter: opacity(0%)` と `color: rgba(0,0,0,0)`** で、`visibility: hidden` / `display: none` は使わない(スクリーンリーダーが要素ごと無視する)。`opacity` 属性でなく `filter` なのは効かない要素があるため。既定は `pointer-events: none`(マウスは canvas に通す)で、F2 を採る要素だけ `auto` に上げる。デバッグ用に `outline: 1px solid green` を出すフラグを最初から入れる(`border` はレイアウトを動かすので使わない)。
+- **DOM → `ActionRequest`。** ここが `web-basics` に丸ごと無い部分。要素ごとに listener を張り、`ActionHandler::do_action` に流す。
+
+  | DOM イベント | 送る `ActionRequest` |
+  |---|---|
+  | `click` | `Action::Click` |
+  | `focus`(DOM 側でフォーカスが移った) | `Action::Focus` |
+  | `keydown` Enter / Space(role が button 相当) | `Action::Click` |
+  | `input` / `change`(role が slider / spinbutton) | `Action::SetValue` + `ActionData::NumericValue` |
+  | `change`(role が checkbox / switch) | `Action::Click`(egui は toggle を Click で受ける) |
+
+  `target_tree` は `TreeId::ROOT`、`target_node` は要素に紐付けた `NodeId`。floers も同じ結論に達している(1.1): `ActionHandler` は adapter が実装するものではなく、**adapter が呼んで外に出すための口**である。
+
+  **クリックの二重発火に注意。** スクリーンリーダーが合成する `click` と、ユーザーが canvas を押した本物のポインタ操作の両方が同じウィジェットに届きうる。Flutter は `ClickDebouncer` で 200ms / 50ms の時間窓を作って見分けている(1.4)。我々の場合はミラーが既定で `pointer-events: none` なので、DOM の `click` が来る = 支援技術が合成したもの、という切り分けが最初から効く。F2 で `auto` に上げた要素だけ同じ問題が出るので、そのときに考える。
+- **要素の種類。** Flutter に倣い、効く場所では本物の要素を使う。`Role::Slider` → `<input type="range" role="slider">`、`Role::TextInput` → `<input>`、`Role::Link` → `<a href>`。checkbox は `role="checkbox"` + `aria-checked` の `<div>` でよい(Flutter もそうしている)。ラベルは `aria-label` 一本にしない(1.4 の `LabelRepresentation`。`aria-label` は JAWS とクローラに効かない)。まず `aria-label`、VoiceOver で足りなければテキストノードに替える。
+- **Tab 順。** `is_focusable(&filter)` が真なら `tabindex="0"`(`web-basics` は `-1` 固定)。ツリー順が DOM 順なので、Tab の順序は egui のウィジェット順になる。F1 を採る場合はホスト全体を `tabindex="-1"` にして canvas 1 個だけを Tab 対象にする。
+- **filter は `accesskit_consumer::common_filter` のまま。** 0.38 の `common_filter` は「親が children を clip していて、自分の矩形が親の外にあり、前後の兄弟も外なら subtree を除く」を既にやる(`filters.rs:54`)。`ScrollArea` の外に出た行はミラーにも出ない。スクロール直後の 1 つ前後だけは残すので、支援技術が `ScrollIntoView` を投げる足がかりもある。
+- **role の対応表はほぼそのまま使う。** 150 行の `match` は accesskit の `Role` が増えた以外は有効。`Role::Window`(egui の root ノード)を `web-basics` は `application` にしていた(ブランチの最終コミットがまさに "Set application role on the root node")が、`role="application"` はスクリーンリーダーの browse mode を切るので、**採否を VoiceOver で確かめてから決める**。関連して、role を付けない素のテキストは Safari が勝手にマージすることが Flutter で報告されている([#166787](https://github.com/flutter/flutter/issues/166787))ので、`Role::Label` にも role を明示する。
+
+対象ウィジェットは task.md のとおり Button / Checkbox / Label / TextEdit / Slider / ComboBox。**TextEdit だけは別扱いになる。** egui が `ActionRequest` で受けるのは `Action::SetValue`(Slider / DragValue のみ、`widgets/slider.rs:755`)と `Action::SetTextSelection`(`text_selection/cursor_range.rs:188`)で、**テキストの入力そのものを受ける経路は無い**。web では eframe の text agent(隠し `<input>`)がすでにキーボードを受けているので、TextEdit ノードのミラーは「名前と値を読み上げさせる `role="textbox"`」に留め、入力は text agent に任せる(フォーカスを text agent に渡す)。
+
+### 2.2 ランナーが `accesskit_update` を受け取る口
+
+3 案ある。
+
+| 案 | やり方 | 判定 |
+|---|---|---|
+| A | eframe を fork し、`WebOptions` に `accesskit_sink: Option<Box<dyn FnMut(TreeUpdate)>>` を足して `handle_platform_output` から呼ぶ | fork が要る。上流に出すまで main に入らない |
+| B | 自前の web ランナーを書く(`egui::Context` + `egui-wgpu` + 入力の橋渡しを全部自分で) | text agent / IME / タッチ / リサイズ / storage を全部書き直すことになる。eframe web は 15 ファイルある。**採らない** |
+| C | **egui の `Plugin::output_hook` で拾う**(1.2(b)) | crates.io の eframe / egui のまま動く。native でも kittest でも同じコードが動く |
+
+**C を採る。** 1.2 で分かったとおり、これは fork も自前ランナーも要らない。試作は `react-egui-app` の `Options::setup` から 2 行で始められる。
+
+```rust
+// spike ブランチの gallery/src/main.rs
+Options {
+    setup: Some(Box::new(|cc| {
+        cc.egui_ctx.enable_accesskit();
+        cc.egui_ctx.add_plugin(react_egui_app::a11y::WebA11y::new("react_egui_canvas"));
+    })),
+    ..Default::default()
+}
+```
+
+`WebA11y` は `react-egui-app` 側の薄い glue(`#[cfg(target_arch = "wasm32")]`)で、`accesskit_web::Adapter` を `thread_local!` に持ち、`Plugin` の 2 つの穴を繋ぐだけ。
+
+```rust
+impl egui::plugin::Plugin for WebA11y {
+    fn debug_name(&self) -> &'static str { "react_egui_web_a11y" }
+
+    fn output_hook(&mut self, _ctx: &egui::Context, output: &mut egui::FullOutput) {
+        if output.platform_output.requested_discard() { return; }   // 5.3 の捨てられるパス
+        let Some(update) = output.platform_output.accesskit_update.take() else { return; };
+        with_adapter(self.key, |a| a.update_if_active(|| update));
+    }
+
+    fn input_hook(&mut self, _ctx: &egui::Context, input: &mut egui::RawInput) {
+        with_pending_actions(self.key, |req| {
+            input.events.push(egui::Event::AccessKitActionRequest(req));
+        });
+    }
+}
+```
+
+**B を採らない理由をもう一つ。** ARCHITECTURE 8 章は「ライブラリ本体は `&mut egui::Ui` しか触らないので、プラットフォーム対応はランナー層に閉じる」と書いている。自前ランナーはその閉じ込めを web でだけ太らせる方向で、iOS ランナー(7 章)とは事情が違う(iOS は eframe が対応していないので選択肢が無い)。web には eframe がある。
+
+**上流に出す形は A ではなく「eframe が adapter を持つ」。** 1.3 のとおりフォーカスの扱いは eframe の内側にあるので、コールバックだけ生やしても呼び手が正しく書けない。C は「上流が入るまでの外付け」であって、上流提案そのものではない。
+
+### 2.3 フォーカスの往復
+
+**ここが本タスクで唯一「誰も答えを持っていない」場所である。** AccessKit のメンテナが `web-basics` の試作を「フォーカスの移動が信頼できない」と評して止めており(1.1)、Flutter は 3 つの仕掛け(遅延 focus / blur を呼ばない / エコー抑制)でようやく回している(1.4)。試作の成果物はここの実測値だと考える。
+
+1.3 の F1 / F2。実装順は F1 → 測る → 必要なら F2。
+
+- egui → DOM: `TreeChangeHandler::focus_moved` で、F1 なら canvas の `aria-activedescendant` を差し替え、F2 なら `element.focus()`。**Flutter に倣って 3 点を守る**: (a) `focus()` はツリーの更新を全部反映し終えてから呼ぶ、(b) **`blur()` は呼ばない**(`web-basics` は呼んでいる)、(c) 同じノードへの再設定は握り潰す。
+- DOM → egui: 要素の `focus` イベント(F2)か、canvas の `keydown` で Tab を捕まえて次のノードを自分で決める(F1)。どちらも `Action::Focus` を送る。egui は `Memory` でこれを受けて `id_requested_by_accesskit` に置く(`egui/src/memory/mod.rs:610`)。**直前に自分が要求したフォーカスの `focus` イベントは送り返さない**(エコーで無限ループになる。Flutter の `_lastEvent == requestedFocus` と同じ)。
+- ホスト全体のフォーカス: `Adapter::update_host_focus_state(is_focused)` に eframe の「canvas か text agent にフォーカスがあるか」を毎フレーム渡す。plugin からは `ctx.input(|i| i.focused)` で読める。
+
+### 2.4 いつ有効にするか
+
+`ctx.enable_accesskit()` は毎フレーム全ウィジェットぶんの `accesskit::Node` を作るので、常時 on にはしない。Flutter web は「窓の外の 1px の `<button aria-label="Enable accessibility">` がクリックされたら」で判定している(1.4)。
+
+**試作は常時 on にする。** 目的が「支援技術から使えるか」の確認なので、有効化の作法まで一度に確かめると原因の切り分けができない。有効化の設計は上流に持ち込むときの論点として残し、AccessKit の `ActivationHandler`(`request_initial_tree`)がすでにその形の穴なので、adapter の API はそれに合わせておく(2.1)。react-egui 側に `Options.a11y: bool` を置くのは、上流の形が決まってからでよい。
+
+### 2.5 main に入るラベル固め
+
+adapter の有無に関わらず効く。**「名前の無いウィジェット」はミラーがあっても読み上げようが無い**ので、先に潰す。
+
+egui 0.36 の API を確認した結果、必要な道具は揃っている。
+
+- `egui::Image::alt_text(impl Into<String>)` が `WidgetInfo.label` に入り、そのまま AccessKit ノードの `label` になる(`egui/src/widgets/image.rs:272, 407`)。エラー時の ⚠ プレースホルダの隣にも描かれる。
+- 任意のウィジェットの名前を後から上書きするなら `Context::accesskit_node_builder(id, |node| node.set_label(..))`(`context.rs:3681`、public。accesskit が無効なら `None` を返すだけ)。`Response::widget_info` を使う手もあるが、こちらはクリックしたフレームに `OutputEvent` をもう 1 つ積んでしまうので採らない。
+
+変更は 2 つだけにする。
+
+| 要素 | 追加する prop | 実装 |
+|---|---|---|
+| `Image` | `alt: Option<&str>` | `image = image.alt_text(alt)` |
+| `Button` | `label: Option<&str>` | `ui.ctx().accesskit_node_builder(resp.id, \|n\| n.set_label(label))`。children は見た目のまま |
+
+`Checkbox` / `Slider` / `ComboBox` はすでに `label: Option<&str>` を持っている。持っているのに渡していない場所があるのが実際の問題で、`examples/todo` の行内チェックボックスがそれ(`examples/todo/src/lib.rs:118`。名前が空)。`x` ボタン(同 124 行)も「x」としか読まれない。examples を直し、**同じ穴が再発しないよう kittest で塞ぐ**(4 章)。
+
+ARCHITECTURE / README に足す一文は次の趣旨。
+
+- ARCHITECTURE 1 章の非ゴール: 「web のスクリーンリーダー対応は egui / AccessKit の web 対応に依存する。egui はウィジェットツリーを AccessKit に出しており native では OS のアクセシビリティ API に届くが、web ではそれを DOM に映す adapter が上流に無い(`docs/tasks/a11y/`)。」
+- ARCHITECTURE 8 章(プラットフォーム): 上と同じことを 1 行、`eframe/src/web/app_runner.rs` の `accesskit_update: _` を指して書く。
+- README の gallery 節: 「gallery は canvas に描いているので、web ではスクリーンリーダーから読めない。native では読める。」
+
+## 3. 手順
+
+### この PR(main)
+
+1. **本書と task.md の訂正。** 1.1 で分かった `web-basics` ブランチの存在を task.md の背景表に反映する(「無い」→「リリース版は無い。試作ブランチが 1 本ある」)。コミット。
+2. **`Image` の `alt`、`Button` の `label`。** `crates/react-egui-elements/src/widgets.rs`。kittest を `tests/widgets.rs` に 2 本(A-1、A-2)。コミット。
+3. **examples のラベル埋め。** todo のチェックボックスと `x` ボタン、他の example を一通り見て名前の無いウィジェットを潰す。snapshot が動くなら撮り直す。コミット。
+4. **名前の無いノードを見つける kittest**(A-3)。gallery の全 example を 1 つずつ描き、focusable なノードに空でない名前があることを確かめる。コミット。
+5. **ARCHITECTURE 1 章 / 8 章と README の一文。** README は「Examples」節の gallery の段落(`Every example but one runs in the browser ..`)の末尾に足す。コミット。PR。
+
+### `a11y-spike` ブランチ(この PR の後)
+
+`main` から切る。fork した eframe を入れることになってもこのブランチに閉じる。
+
+6. **`accesskit_web` の骨格を移植する。** `web-basics` の 4 ファイルを `crates/accesskit-web/`(spike のみ)に置き、accesskit 0.24.1 / consumer 0.38 に合わせて直す(`name()` → `label()`、`is_focusable(&filter)`、`TreeId`)。まだ座標もイベントも無い。ビルドが通ることだけ確かめる。
+7. **座標とホストの CSS**(2.1)。`bounding_box()` を `position: absolute` に落とし、canvas に重ねる。DevTools で矩形がウィジェットの上に乗っていることを目視。
+8. **`react_egui_app::a11y::WebA11y`(plugin)と `Options::setup` からの起動**(2.2)。gallery を trunk でビルドし、DOM が毎フレーム更新されることを目視。捨てられたパスを弾く条件がちゃんと効いているかを、taffy が 2 パス回る example(layout)で確かめる。
+9. **DOM → `ActionRequest`**(2.1 の表)。click と Enter / Space で counter の `+` が増えるところまで。
+10. **フォーカス F1**(2.3)。`aria-activedescendant` 版。VoiceOver(macOS Safari / Chrome)で counter / todo / form を触る。
+11. **F1 で足りなければ F2。** eframe を fork し、`has_focus` を「canvas の親の中に activeElement があるか」に緩める。`[patch.crates-io]` で git fork を指す。**このコミットは spike ブランチだけに置く。**
+12. **上流。** AccessKit に discussions#514 の続きとして「web-basics を現行 API に起こし、座標とイベントを足した。引き取れるか」を書く。eframe / egui に「web で AccessKit ツリーが捨てられている。adapter を eframe が持つ形を提案する」の issue を立てる。
+
+## 4. テスト / 確認
+
+### main(headless、CI で回る)
+
+kittest は AccessKit ツリーをそのまま歩く(`egui_kittest::Harness::root()` が返すのは `kittest::AccessKitNode` = `accesskit_consumer::Node`)。ラベル固めは全部 headless で押さえられる。
+
+| # | 場所 | 内容 |
+|---|---|---|
+| A-1 | `crates/react-egui-elements/tests/widgets.rs` | `<Image alt="a cat"/>` を `harness.get_by_label("a cat")` で引ける。`alt` 無しなら引けない |
+| A-2 | 同上 | `<Button label="delete">"x"</Button>` が `get_by_role_and_label(Role::Button, "delete")` で引ける。見た目(`get_by_label("x")` が引く矩形)は変わらない |
+| A-3 | `examples/gallery/tests/` | `gallery::EXAMPLES` を回して `<App start={meta.name}/>` を描き、ツリーを root から辿って「focusable かつ `label()` が空」のノードが無いことを確かめる。見つかったら example 名と role と矩形を出す。**これが 3 の再発防止** |
+
+A-3 は「今後 example を足した人が名前を忘れたら赤くなる」ための仕掛けなので、失敗メッセージに「`label` を渡してください」と書く。窓は既存の `examples/gallery/tests/gallery.rs` と同じ 1280×1000 にする(`ScrollArea` が描かなかったウィジェットはツリーにも居ないので、小さい窓だと見逃す)。
+
+### spike(手で確かめる)
+
+wasm の自動テストは `wasm-bindgen-test` で DOM の形(ノード数、`role`、`aria-label`、矩形)までは書けるが、**支援技術が実際にどう読むかは自動化できない**。VoiceOver の挙動が全てなので、チェックリストを置いて手で回す。
+
+- `wasm-bindgen-test`(headless Chrome): `TreeUpdate` を手で作って `Adapter` に流し、DOM に期待どおりの要素と属性と座標が並ぶこと。差分更新でノードが増減すること。adapter は egui 非依存なので、このテストに egui は出てこない。
+- VoiceOver チェックリスト(macOS、Safari と Chrome の両方。gallery の counter / todo / form):
+
+  | | 確かめること |
+  |---|---|
+  | 1 | VO+右矢印でウィジェットを順に読み、ボタン名が読まれる |
+  | 2 | Tab でフォーカスが移り、VoiceOver のカーソルが追随する |
+  | 3 | Enter / Space でボタンが押され、結果(カウンタの値)が読まれる |
+  | 4 | チェックボックスの「オン/オフ」が読まれ、切り替えられる |
+  | 5 | テキスト欄に入力でき、入力した値が読まれる |
+  | 6 | スライダーの値が読まれ、矢印キーで動かせる |
+  | 7 | ミラーがマウス操作を邪魔していない(`pointer-events`。Flutter が [#188859](https://github.com/flutter/flutter/issues/188859) / [#160560](https://github.com/flutter/flutter/issues/160560) で踏んでいる穴) |
+  | 8 | フォーカスされているノードが**目でも**分かる(egui 側のフォーカスリングが出ている)。Flutter web は透明なミラーのせいでこれが出ず、[#186044](https://github.com/flutter/flutter/issues/186044) が open のまま |
+
+  読み上げの様子は動画に録って上流の issue に貼る。
+
+## 5. 終了条件との対応
+
+task.md の終了条件は 3 つある。この PR で満たせるのは 3 番目だけで、残りは spike の後。
+
+| 終了条件 | どこで |
+|---|---|
+| gallery(web)の counter / todo / form を VoiceOver で読み上げ・Tab・Enter / Space | 手順 10(必要なら 11)、4 章のチェックリスト |
+| 上流に web adapter と eframe の差し込み口の提案が出ている | 手順 12 |
+| ARCHITECTURE.md に web の a11y の現状と方針が書かれている | 手順 5(**この PR**) |
+
+## 6. 実装で判明した差分

--- a/docs/tasks/a11y/plan.md
+++ b/docs/tasks/a11y/plan.md
@@ -375,18 +375,20 @@ A-3 は「今後 example を足した人が名前を忘れたら赤くなる」�
 wasm の自動テストは `wasm-bindgen-test` で DOM の形(ノード数、`role`、`aria-label`、矩形)までは書けるが、**支援技術が実際にどう読むかは自動化できない**。VoiceOver の挙動が全てなので、チェックリストを置いて手で回す。
 
 - `wasm-bindgen-test`(headless Chrome): `TreeUpdate` を手で作って `Adapter` に流し、DOM に期待どおりの要素と属性と座標が並ぶこと。差分更新でノードが増減すること。adapter は egui 非依存なので、このテストに egui は出てこない。
-- VoiceOver チェックリスト(macOS、Safari と Chrome の両方。gallery の counter / todo / form):
+- VoiceOver チェックリスト(macOS、Safari と Chrome の両方。gallery の counter / todo / form)。
 
-  | | 確かめること |
-  |---|---|
-  | 1 | VO+右矢印でウィジェットを順に読み、ボタン名が読まれる |
-  | 2 | Tab でフォーカスが移り、VoiceOver のカーソルが追随する |
-  | 3 | Enter / Space でボタンが押され、結果(カウンタの値)が読まれる |
-  | 4 | チェックボックスの「オン/オフ」が読まれ、切り替えられる |
-  | 5 | テキスト欄に入力でき、入力した値が読まれる |
-  | 6 | スライダーの値が読まれ、矢印キーで動かせる |
-  | 7 | ミラーがマウス操作を邪魔していない(`pointer-events`。Flutter が [#188859](https://github.com/flutter/flutter/issues/188859) / [#160560](https://github.com/flutter/flutter/issues/160560) で踏んでいる穴) |
-  | 8 | フォーカスされているノードが**目でも**分かる(egui 側のフォーカスリングが出ている)。Flutter web は透明なミラーのせいでこれが出ず、[#186044](https://github.com/flutter/flutter/issues/186044) が open のまま |
+  **状態: まだ回していない。人間が要る。** 手順 10 までは headless Chrome で確かめられる範囲を全部確かめたが(6.10)、支援技術が実際にどう読むかは自動化できないと 4 章の頭に書いたとおりで、下の 8 行は人が VoiceOver を入れて触るまで空欄のままである。**F1 を続けるか F2 に落ちるかはこの表の結果で決まる**ので、手順 11 に進む前にここを埋める。1 と 2 が落ちるなら F2、通るなら F1 のまま上流に出せる。
+
+  | | 確かめること | 結果 |
+  |---|---|---|
+  | 1 | VO+右矢印でウィジェットを順に読み、ボタン名が読まれる | 未 |
+  | 2 | Tab でフォーカスが移り、VoiceOver のカーソルが追随する | 未 |
+  | 3 | Enter / Space でボタンが押され、結果(カウンタの値)が読まれる | 未 |
+  | 4 | チェックボックスの「オン/オフ」が読まれ、切り替えられる | 未 |
+  | 5 | テキスト欄に入力でき、入力した値が読まれる | 未 |
+  | 6 | スライダーの値が読まれ、矢印キーで動かせる | 未 |
+  | 7 | ミラーがマウス操作を邪魔していない(`pointer-events`。Flutter が [#188859](https://github.com/flutter/flutter/issues/188859) / [#160560](https://github.com/flutter/flutter/issues/160560) で踏んでいる穴) | 未 |
+  | 8 | フォーカスされているノードが**目でも**分かる(egui 側のフォーカスリングが出ている)。Flutter web は透明なミラーのせいでこれが出ず、[#186044](https://github.com/flutter/flutter/issues/186044) が open のまま | 未 |
 
   読み上げの様子は動画に録って上流の issue に貼る。
 
@@ -402,7 +404,7 @@ task.md の終了条件は 3 つある。3 番目は PR #4 で済み、1 番目�
 
 ## 6. 実装で判明した差分
 
-手順 2〜5(PR #4、ラベル固め)は 6.1〜6.5、手順 6〜9(PR #5、ミラー本体)は 6.6〜6.9。
+手順 2〜5(PR #4、ラベル固め)は 6.1〜6.5、手順 6〜9(PR #5、ミラー本体)は 6.6〜6.9、手順 10(フォーカス F1)は 6.10。
 
 ### 6.1 `Button` の `label` は 3 章のとおり。`Image` の `alt` も同じ
 
@@ -472,3 +474,48 @@ counter と custom-hook のボタン。名前は空ではない(「プラス」�
 - 2.1 の表のうち `input` / `change` は、ミラーが今 `<div>` なので実際には飛んでこない(本物の `<input>` にしたときのため)。チェックボックスの toggle は合成 `click` の方で届く。
 - **headless Chrome での実測**(gallery、`?a11y-debug`): ミラーの button を `click()` すると example が切り替わり、counter の `+` で数が増える。`keydown` の Enter / Space も効く。`elementFromPoint` はミラーではなく canvas を返す(`pointer-events: none` が効いている)。
 - `crates/accesskit-web/tests/mirror.rs` は `#![cfg(target_arch = "wasm32")]` で囲ってあるので `cargo test --workspace` は素通りする。`wasm-pack test --headless --chrome crates/accesskit-web` で 4 本通る。
+
+### 6.10 手順 10: フォーカス F1 と、値ウィジェットの本物の要素
+
+**DOM → egui は書くものが無かった。** 2.3 は「canvas の `keydown` で Tab を捕まえて次のノードを自分で決める」と書いていたが、実測すると **eframe と egui がすでに両方やっていた**。
+
+- eframe の `keydown` listener は canvas に張ってあり(`web/events.rs:83`)、Tab を `egui::Key::Tab` としてそのまま egui に渡したうえで `prevent_default()` する(同 269 行、コメントに「egui uses Tab to move focus within the egui app」とある)。ブラウザが次の HTML 要素にフォーカスを移すことは無い。
+- egui 側は `Memory::begin_pass` が Tab / Shift+Tab を `FocusDirection::Next` / `Previous` に変え(`memory/mod.rs:596`)、`end_pass` でウィジェットを選ぶ。
+
+つまり **F1 の DOM → egui 方向は「何もしない」が正解**で、自前の Tab 走査を書くと egui と二重に動く。手順 10b はミラー側では 1 行も書かず、`focus_moved` で `aria-activedescendant` を追随させるだけにした。エコー抑制も要らない(ミラーは `focus()` を呼ばないので、返ってくるフォーカスイベントが無い)。
+
+**`aria-activedescendant` を正当にするのに 2 つ足りなかった。** 調べた結果、参照先は「参照元の DOM の子孫」か「`aria-owns` で参照元が所有している要素」のどちらかである必要がある(WAI-ARIA 1.2 の `aria-activedescendant`、APG の "Developing a Keyboard Interface")。ミラーのホストは canvas の**兄弟**なので、canvas に `aria-owns="<host id>"` を付けた。さらにこの属性が許されるのは `application` / `combobox` / `composite`(とその派生)/ `group` / `textbox` の role だけで、素の `<canvas>` はどれでもない。そこで **canvas に `role="application"` を付けた** — 2.1 で「VoiceOver で確かめてから決める」と保留にしていた判断を、ここで採ったことになる。Chrome の a11y ツリーでミラー全体が canvas(application)の下にぶら下がることは確認した。
+
+- **代案として「ミラーを canvas の子にする」**(canvas fallback content)がある。子孫になるので `aria-owns` も `role` も要らない。採らなかったのは、1.5 のとおり fallback content の要素は**描画ボックスを持たない**ので、我々が手順 7 で入れた座標が意味を失うからである。上流に出すときの選択肢としては残る。
+- **支援技術の対応は薄い。** VoiceOver + Safari は **Safari 18(2024)で直るまで `aria-activedescendant` を無視していた**([WebKit#167680](https://bugs.webkit.org/show_bug.cgi?id=167680))。`aria-owns` は macOS 14.3 / iOS 17.3 より前の VoiceOver に出ない。iOS / Android のタッチ系支援技術は a11y ツリーを直接なぞるので、この属性を事実上見ない。**F1 は「今の Safari なら通るかもしれない」程度**で、1.3 の見立て(F2 が本命)は変わっていない。4 章の表を人が埋めるまで結論は出ない。
+
+**1.4 の 3 つの規則はそのまま守った。**(a) `focus_moved` は**記録するだけ**にし、属性を書くのは `update_and_process_changes` が返った後。consumer は `focus_moved` を `node_removed` より前に呼ぶので、記録しないと消える途中の DOM を指しうる。(b) `blur()` に当たるのは「アプリがフォーカス無しを報告したときに属性を消すこと」なので、**消さない**。(c) 同じノードへの再設定は握り潰す。例外は 1 つだけで、**参照先の要素が木から消えたときは属性を外す**(宙に浮いた参照は無いより悪い)。
+
+**`aria-selected` は付けなかった。** 10 の指示にはあったが、この属性は listbox の option や grid の row など一部の role でしか意味を持たず、button に付ければ支援技術に嘘をつくことになる。フォーカスの主張は canvas の `aria-activedescendant` 1 本に絞り、ミラー側は **`data-focused="true"`** という印だけにした。`?a11y-debug` では、フォーカス中のノードだけ枠をマゼンタにする(他は緑のまま)。
+
+**`tabindex` は `"0"` から `"-1"` に落とした**(ホストも `-1`)。手順 7 の宿題(6.7 の最終行)がこれで片付く。focusable なノードに属性を出すこと自体は残してあるので、「どれがアプリのフォーカス先か」は DOM を見れば分かる。
+
+**値ウィジェットは本物の要素にした**(手順 9 で残した穴、6.9 の 4 点目)。
+
+- `Role::Slider` / `Role::SpinButton` → `<input type="range">`。`min` / `max` / `step` はノードの数値から。`step` が無いと range は整数に丸めるので、無いときは `any` を入れる。
+- `Role::TextInput` → `<input type="text" readonly>`。**readonly はミラーが打鍵を取らないため**で、入力は 2.1 のとおり eframe の text agent に任せる。
+- **値は属性ではなくプロパティで書く。** 支援技術が range を動かした後は、`value` 属性は `defaultValue` にしかならず、表示が egui から離れる。DOM の値がアプリの値と違うときだけ上書きする形にした。
+- `role` 属性はそのまま残してあるので、6.9 で書いた `NUMERIC_ROLES` の判定(`input` / `change` → `SetValue`)がそのまま効く。`aria-valuenow` / `valuemin` / `valuemax` も全ノードに出したままで、`<div>` のままの role の取り分になる。
+- checkbox は Flutter と同じく `<div role="checkbox">` + `aria-checked` のまま。
+- role が変わって `<div>` と `<input>` を跨ぐときは要素を作り直し、子要素は移し替える(タグは後から変えられないため)。egui のノード id はウィジェットごとに安定なので実際にはまず起きない。
+
+**headless Chrome での実測**(`trunk build` した gallery を配って `?a11y-debug`)。
+
+- **counter**: canvas をクリックしてから Tab を送ると、canvas の `aria-activedescendant` が `window` → `showcase` → `counter` と動き、Shift+Tab で戻る。**`document.activeElement` は canvas のまま**で、`data-focused` の付いたノードと参照先は常に一致する。`+` まで Tab して Enter を押すとカウントが 1 → 2 に増えた。
+- **form**: ミラーの slider は `<input type="range" min="0" max="100" step="1">` で値は 50。`value = 80` にして `input` イベントを投げると、次のフレームで egui 側が 80 になった(要約行が「volume 80」)。TextEdit は `<input type="text" readonly value="anon">`。
+- **`elementFromPoint` は canvas を返す。** `pointer-events` は継承されるので、ホストの `none` が `<input>` にも効いている(4 章の 7 番目、Flutter が踏んだ穴)。
+- **canvas を blur しても `aria-activedescendant` は残り、戻しても同じ**。`data-focused` だけが消えて戻る(10d の確認)。
+- **TextEdit にフォーカスが移った瞬間だけ `document.activeElement` が `<input>` になる**が、これはミラーではなく **eframe の text agent** である。eframe の `has_focus` はこれも「フォーカスあり」と数えるので(1.3)、問題は起きない。
+- コンソールにエラーは出ない。
+
+**残っている穴。**
+
+- **VoiceOver の実機は未確認**(4 章)。F1 / F2 の判定はそこで初めて付く。
+- `Role::MultilineTextInput` は `<div role="textbox">` のまま。`<textarea>` にするかは、テキスト欄の読み上げを一度見てから決める。
+- form の slider の隣に出る `SpinButton`(egui の `DragValue`)は `step` がドラッグの刻み(1.12…)になる。矢印キーで動かす分には粗すぎるので、`numeric_value_step` を使うかどうかは role ごとに分ける余地がある。
+- `aria-owns` はミラーを canvas の下に付け替えるので、canvas 自身の子(将来 eframe が何か置いたら)との順序は保証しない。

--- a/docs/tasks/a11y/plan.md
+++ b/docs/tasks/a11y/plan.md
@@ -377,18 +377,18 @@ wasm の自動テストは `wasm-bindgen-test` で DOM の形(ノード数、`ro
 - `wasm-bindgen-test`(headless Chrome): `TreeUpdate` を手で作って `Adapter` に流し、DOM に期待どおりの要素と属性と座標が並ぶこと。差分更新でノードが増減すること。adapter は egui 非依存なので、このテストに egui は出てこない。
 - VoiceOver チェックリスト(macOS、Safari と Chrome の両方。gallery の counter / todo / form)。
 
-  **状態: まだ回していない。人間が要る。** 手順 10 までは headless Chrome で確かめられる範囲を全部確かめたが(6.10)、支援技術が実際にどう読むかは自動化できないと 4 章の頭に書いたとおりで、下の 8 行は人が VoiceOver を入れて触るまで空欄のままである。**F1 を続けるか F2 に落ちるかはこの表の結果で決まる**ので、手順 11 に進む前にここを埋める。1 と 2 が落ちるなら F2、通るなら F1 のまま上流に出せる。
+  **状態: 回した(2026-09-05、macOS)。8 項目とも通った。F1 で成立し、手順 11(F2、eframe fork)は不要。** 1 は最初 `Cmd+Option+→` を押していてブラウザのタブ切替になっただけで、VO キー(`Ctrl+Option`)で動いた。canvas が `role="application"` なので、VO カーソルが中に降りない場合は `VO+Shift+↓` で一段入る。ブラウザの版は未記録。
 
   | | 確かめること | 結果 |
   |---|---|---|
-  | 1 | VO+右矢印でウィジェットを順に読み、ボタン名が読まれる | 未 |
-  | 2 | Tab でフォーカスが移り、VoiceOver のカーソルが追随する | 未 |
-  | 3 | Enter / Space でボタンが押され、結果(カウンタの値)が読まれる | 未 |
-  | 4 | チェックボックスの「オン/オフ」が読まれ、切り替えられる | 未 |
-  | 5 | テキスト欄に入力でき、入力した値が読まれる | 未 |
-  | 6 | スライダーの値が読まれ、矢印キーで動かせる | 未 |
-  | 7 | ミラーがマウス操作を邪魔していない(`pointer-events`。Flutter が [#188859](https://github.com/flutter/flutter/issues/188859) / [#160560](https://github.com/flutter/flutter/issues/160560) で踏んでいる穴) | 未 |
-  | 8 | フォーカスされているノードが**目でも**分かる(egui 側のフォーカスリングが出ている)。Flutter web は透明なミラーのせいでこれが出ず、[#186044](https://github.com/flutter/flutter/issues/186044) が open のまま | 未 |
+  | 1 | VO+右矢印でウィジェットを順に読み、ボタン名が読まれる | ○ |
+  | 2 | Tab でフォーカスが移り、VoiceOver のカーソルが追随する | ○ |
+  | 3 | Enter / Space でボタンが押され、結果(カウンタの値)が読まれる | ○ |
+  | 4 | チェックボックスの「オン/オフ」が読まれ、切り替えられる | ○ |
+  | 5 | テキスト欄に入力でき、入力した値が読まれる | ○ |
+  | 6 | スライダーの値が読まれ、矢印キーで動かせる | ○ |
+  | 7 | ミラーがマウス操作を邪魔していない(`pointer-events`。Flutter が [#188859](https://github.com/flutter/flutter/issues/188859) / [#160560](https://github.com/flutter/flutter/issues/160560) で踏んでいる穴) | ○ |
+  | 8 | フォーカスされているノードが**目でも**分かる(egui 側のフォーカスリングが出ている)。Flutter web は透明なミラーのせいでこれが出ず、[#186044](https://github.com/flutter/flutter/issues/186044) が open のまま | ○ |
 
   読み上げの様子は動画に録って上流の issue に貼る。
 
@@ -515,7 +515,7 @@ counter と custom-hook のボタン。名前は空ではない(「プラス」�
 
 **残っている穴。**
 
-- **VoiceOver の実機は未確認**(4 章)。F1 / F2 の判定はそこで初めて付く。
+- **VoiceOver の実機は 8 項目とも通った**(4 章)。F1 のまま上流に出す。
 - `Role::MultilineTextInput` は `<div role="textbox">` のまま。`<textarea>` にするかは、テキスト欄の読み上げを一度見てから決める。
 - form の slider の隣に出る `SpinButton`(egui の `DragValue`)は `step` がドラッグの刻み(1.12…)になる。矢印キーで動かす分には粗すぎるので、`numeric_value_step` を使うかどうかは role ごとに分ける余地がある。
 - `aria-owns` はミラーを canvas の下に付け替えるので、canvas 自身の子(将来 eframe が何か置いたら)との順序は保証しない。

--- a/docs/tasks/a11y/plan.md
+++ b/docs/tasks/a11y/plan.md
@@ -390,3 +390,41 @@ task.md の終了条件は 3 つある。この PR で満たせるのは 3 番�
 | ARCHITECTURE.md に web の a11y の現状と方針が書かれている | 手順 5(**この PR**) |
 
 ## 6. 実装で判明した差分
+
+手順 2〜5(main に入るラベル固め)を実装したときに分かったこと。
+
+### 6.1 `Button` の `label` は 3 章のとおり。`Image` の `alt` も同じ
+
+`ui.ctx().accesskit_node_builder(response.id, |node| node.set_label(label))` は egui 0.36.1 でそのまま通る(`Context::accesskit_node_builder(Id, impl FnOnce(&mut accesskit::Node) -> R) -> Option<R>`)。ウィジェットが自分のノードを書いた後に呼べば名前を上書きでき、accesskit が無効なら `None` が返るだけで何も起きない。描くものは変わらないので、生 egui 版と並べる example でもピクセルが動かない。
+
+### 6.2 名前を付けられないウィジェットが残った
+
+A-3(`examples/gallery/tests/a11y.rs`)を書いて全 example を走らせたところ、focusable で名前が空のノードが 13 個出た。**そのどれも、今の要素の API では「描くものを変えずに」名前を付けられない。**
+
+| 出たもの | なぜ付けられないか |
+|---|---|
+| `TextInput`(showcase / todo / form / custom-hook / list-10k) | `egui::TextEdit` は AccessKit ノードに label を一切書かない。`hint_text` は `PlatformOutput`(web screen reader 用の読み上げ文)に行くだけでノードには乗らない。`<TextEdit>` にも名前の prop が無い |
+| `form` の `CheckBox` ×2 / `Slider` / `SpinButton` / `ComboBox` | ラベルは隣の列(`<Field>`)が描いている。AccessKit ではこれは `labelled_by` 関係で、要素は `Response::labelled_by` を出していない。各要素が持つ `label` prop は**文字を描く**ので、名前が画面に 2 回出て、隣に並ぶ生 egui 版ともズレる |
+| `escape-hatch` の `ColorWell` | 生の `ui.color_edit_button_srgba`。egui が名前を付けていない |
+| `shader` の `Unknown` | `<Canvas>` の leaf。コントロールではなく描画面なので、canvas 一般の扱いを決めてからにする |
+
+そこで A-3 は「focusable で名前が空のノードが 0」ではなく、**この 13 個を `KNOWN_UNNAMED` として並べ、完全一致で比べる**形にした。名前の無いウィジェットが増えれば落ち、既知のものを直したときも(表から消し忘れれば)落ちる。リストは減る方向にしか動かない。
+
+続きとして要るもの。どちらも要素の API を増やす話なので、この PR には入れない。
+
+1. `<TextEdit>` に `Button` と同じ「描かない名前」を足す。上の 5 個が消える。
+2. `<Field>` のような「隣のラベル」を AccessKit に繋ぐ道(`Response::labelled_by` 相当)。form の 5 個が消える。
+
+### 6.3 `examples/todo` の行内チェックボックスは直せなかった
+
+2.5 で「実際の問題」と書いた場所。名前を与える唯一の口である `label` prop は文字を描くので、行の見た目が変わり、同じ絵と比べている生 egui 版(と `snapshot` の画像)とズレる。6.2 の 1 と同じ「描かない名前」が要る。なお既定の todo は空リストで始まるので、この行は A-3 のツリーには出てこない。
+
+`x` ボタン(2.5 のもう 1 つ)は `label="remove"` で直した。生 egui 版にも同じ名前を `accesskit_node_builder` で手で付けてある。両方を同じ手順で driving しているテストがラベルで引いているため、かつ「同じアプリ」であるべきだからである。`list-10k` の `x` も同じ。
+
+### 6.4 `+` / `-` はそのままにした
+
+counter と custom-hook のボタン。名前は空ではない(「プラス」「マイナス」と読まれる)し、隣に数が出ているので意味は通る。直すと生 egui 版と react-egui 版を同じ手順で driving しているテストが片方だけズレるため、費用の方が大きいと判断した。
+
+### 6.5 A-3 は `run` ではなく `run_steps(2)`
+
+`shader`(と `clock`)は毎フレーム再描画を要求するので、`Harness::run` が「4 ステップで落ち着かない」と panic する。`fetch` は描いた瞬間に本物の HTTP を投げるので、既存の `gallery.rs` と同じ理由で外してある。

--- a/docs/tasks/a11y/task.md
+++ b/docs/tasks/a11y/task.md
@@ -54,7 +54,7 @@ react-egui の要素は egui の widget をそのまま使っているので、n
 ## 終了条件
 
 - gallery(web)の counter / todo / form を、VoiceOver でボタン名・チェック状態・テキスト欄の値が読み上げられ、Tab で移動し、Enter / Space で操作できる(目視)。
-- 上流に web adapter と eframe の差し込み口の提案が出ている(マージは条件にしない)。
+- ~~上流に web adapter と eframe の差し込み口の提案が出ている(マージは条件にしない)。~~ 2026-09-05 に取り下げ。上流には出さず、`accesskit-web` と `WebA11y` を react-egui の中で持ち続ける。
 - ARCHITECTURE.md に web の a11y の現状と方針が書かれている。
 
 ## 決めごと(着手時点での前提)

--- a/docs/tasks/a11y/task.md
+++ b/docs/tasks/a11y/task.md
@@ -1,0 +1,70 @@
+# タスク: a11y(web のアクセシビリティ、時期未定)
+
+## 目的
+
+web(wasm)で動く react-egui アプリを、スクリーンリーダーとキーボード操作の支援技術から使えるようにする。native では egui が AccessKit 経由で OS のアクセシビリティ API にウィジェットツリーを渡しているが、web ではそのツリーが捨てられている。描画は canvas のまま、アクセシビリティツリーだけを DOM に鏡写しにする(Flutter web の semantics 層と同じ方式)。
+
+これは react-egui 固有の問題ではなく egui / AccessKit / eframe の未完成部分なので、成果は上流(AccessKit の web adapter、eframe の差し込み口)に出すことを前提にする。react-egui は「上流に入れば自動で恩恵を受ける」位置にあり、本タスクは試作でその形を確かめ、上流に持ち込むところまでを範囲とする。
+
+## 背景(2026-09 時点、egui / eframe 0.36)
+
+| 層 | 状態 |
+|---|---|
+| egui → AccessKit ツリー | ある。`Context::enable_accesskit()` を呼ぶと毎フレーム `PlatformOutput.accesskit_update: Option<TreeUpdate>` に差分が出る。web でも動く |
+| AccessKit → OS(native) | ある。macOS / Windows / Unix(AT-SPI)/ Android。egui-winit が `enable_accesskit` を呼び、adapter に渡す |
+| AccessKit → DOM(web) | **無い**。AccessKit に web adapter が存在しない |
+| eframe web でツリーを受け取る口 | **無い**。`eframe/src/web/app_runner.rs` が `accesskit_update: _, // not currently implemented` と捨てている。`App::update` からは `FullOutput` に触れない |
+| web の代替 | `web_screen_reader` feature(既定 on)。`Options.screen_reader = true` のときだけ、起きたイベントの説明文を `speechSynthesis` で読み上げる。ツリーもフォーカス移動も無い |
+| ツリーの保持 | `accesskit_consumer` が `TreeUpdate` を適用して歩ける(`Tree::new` / `update_and_process_changes`、`Node::role() / label() / value() / bounding_box() / is_focused()`)。kittest が同じ経路を使っている |
+| 逆方向 | 支援技術からの操作は `accesskit::ActionRequest`(Click / Focus / SetValue など)。egui は `Event::AccessKitActionRequest` として受け取って処理する |
+
+react-egui の要素は egui の widget をそのまま使っているので、native の対応はそのまま享受している(kittest がラベルで要素を探せているのがその証拠)。
+
+## スコープ
+
+### 含む
+
+- **調査**: AccessKit に web adapter の議論 / 実装が無いかの確認(issue、ブランチ、他プロジェクトの試み)。Flutter web の semantics 層の構造(要素の種類、フォーカス同期、イベントの戻し方、既知の弱点)を読む。
+- **試作(react-egui 内で閉じる)**:
+  - eframe を fork するか自前の web ランナーを書き、`accesskit_update` を受け取る。
+  - `TreeUpdate` を `accesskit_consumer` で保持し、canvas の上に透明な DOM 要素(`role` / `aria-label` / `aria-valuenow` / 絶対座標)として並べる。
+  - フォーカスの同期(egui → DOM の `focus()`、DOM → egui の `ActionRequest::Focus`)。
+  - DOM の click / keydown / input を `ActionRequest` に変換して egui に戻す。
+  - 対象ウィジェット: Button / Checkbox / Label / TextEdit / Slider / ComboBox(react-egui-elements の全ウィジェット)。
+  - gallery で VoiceOver(macOS Safari / Chrome)から操作できることを目視。
+- **上流化**: 試作で確かめた形を、AccessKit の web adapter(新 crate)と eframe の差し込み口(`WebOptions` へのコールバック等)として PR に切り出す。
+- **react-egui 側の整備**(上流と独立に今できること):
+  - 要素の `label` を必須に近づける(`Image` の代替テキスト、アイコンだけの `Button` の `aria-label` 相当)。
+  - ARCHITECTURE.md 1 章の非ゴールに「web の a11y は egui / AccessKit の web 対応に依存する」と明記し、README の gallery の説明に一文を足す。
+
+### 含まない
+
+- **DOM で描画し直す backend**(egui を web では使わない)。reconciler を持たない設計(ARCHITECTURE 2.1)、ハンドラがその場で `&mut` を借りる設計、生 egui への出口のすべてと衝突する。それをやるなら Dioxus を使う。
+- テキスト選択、ページ内検索、翻訳、SEO。canvas 描画の限界で、Flutter web も解決していない。
+- native 側の改善(egui / AccessKit の範囲)。
+- IME の改善(別問題)。
+
+## 成果物
+
+- `docs/tasks/a11y/plan.md`(調査結果を反映した詳細プラン。着手時に書く)。
+- 試作コード(fork した eframe か自前ランナー、adapter の原型)。react-egui の main には入れず、ブランチか別リポジトリに置く。
+- 上流への issue / PR(AccessKit、eframe)。
+- ARCHITECTURE.md / README の一文。
+
+## 終了条件
+
+- gallery(web)の counter / todo / form を、VoiceOver でボタン名・チェック状態・テキスト欄の値が読み上げられ、Tab で移動し、Enter / Space で操作できる(目視)。
+- 上流に web adapter と eframe の差し込み口の提案が出ている(マージは条件にしない)。
+- ARCHITECTURE.md に web の a11y の現状と方針が書かれている。
+
+## 決めごと(着手時点での前提)
+
+- 方式は「canvas 描画 + DOM の鏡写し」。描画の置き換えはしない。
+- adapter は egui 非依存(AccessKit の `TreeUpdate` だけを見る)で書き、AccessKit の他の adapter と同じ形にする。egui / react-egui 固有のものは入れない。
+- 試作は react-egui-app の wasm ランナーで閉じて行い、動いたら上流に切り出す。react-egui の main に fork した eframe を依存として入れない。
+- 優先度はフェーズ 8(公開準備)の後。それまでは README に制約を書くだけにする。
+
+## 見積り
+
+- adapter の試作(Button / Checkbox / Label / TextEdit、フォーカスとクリックの往復): 数百行、数日。
+- 実用(Slider / ComboBox / リスト / live region / スクロール / IME との整合): Flutter web の semantics 層が数千行なのが目安。上流での作業。

--- a/docs/tasks/a11y/task.md
+++ b/docs/tasks/a11y/task.md
@@ -12,8 +12,8 @@ web(wasm)で動く react-egui アプリを、スクリーンリーダーとキ�
 |---|---|
 | egui → AccessKit ツリー | ある。`Context::enable_accesskit()` を呼ぶと毎フレーム `PlatformOutput.accesskit_update: Option<TreeUpdate>` に差分が出る。web でも動く |
 | AccessKit → OS(native) | ある。macOS / Windows / Unix(AT-SPI)/ Android。egui-winit が `enable_accesskit` を呼び、adapter に渡す |
-| AccessKit → DOM(web) | **無い**。AccessKit に web adapter が存在しない |
-| eframe web でツリーを受け取る口 | **無い**。`eframe/src/web/app_runner.rs` が `accesskit_update: _, // not currently implemented` と捨てている。`App::update` からは `FullOutput` に触れない |
+| AccessKit → DOM(web) | **リリース版は無い**。crates.io に `accesskit_web` は無く、`web-basics` ブランチに 2024-07 で止まった試作が 1 本あるだけ(plan.md 1.1)|
+| eframe web でツリーを受け取る口 | eframe には**無い**。`eframe/src/web/app_runner.rs` が `accesskit_update: _, // not currently implemented` と捨てており、`App` からは `FullOutput` に触れない。ただし **egui 0.36 の `Plugin::output_hook(&Context, &mut FullOutput)` から拾える**(plan.md 1.2)|
 | web の代替 | `web_screen_reader` feature(既定 on)。`Options.screen_reader = true` のときだけ、起きたイベントの説明文を `speechSynthesis` で読み上げる。ツリーもフォーカス移動も無い |
 | ツリーの保持 | `accesskit_consumer` が `TreeUpdate` を適用して歩ける(`Tree::new` / `update_and_process_changes`、`Node::role() / label() / value() / bounding_box() / is_focused()`)。kittest が同じ経路を使っている |
 | 逆方向 | 支援技術からの操作は `accesskit::ActionRequest`(Click / Focus / SetValue など)。egui は `Event::AccessKitActionRequest` として受け取って処理する |

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -2,19 +2,28 @@
 
 use gallery::{App, initial_example};
 use react_egui::prelude::*;
+use react_egui_app::a11y::WebA11y;
 use react_egui_app::{Options, run};
 
 fn main() -> eframe::Result {
     // Read once, before the first pass: the root closure runs every pass and
     // the hash changes as the user picks examples.
     let start = initial_example();
+    let canvas_id = Options::default().canvas_id;
     run(
         Options {
             title: String::from("react-egui: gallery"),
-            // The shader example's pipeline, built once for the whole gallery.
-            // It lands in `callback_resources` under its own type, so it costs
-            // the other examples nothing and cannot clash with them.
-            setup: Some(Box::new(shader::gpu::setup)),
+            setup: Some(Box::new(move |cc| {
+                // The shader example's pipeline, built once for the whole
+                // gallery. It lands in `callback_resources` under its own
+                // type, so it costs the other examples nothing and cannot
+                // clash with them.
+                shader::gpu::setup(cc);
+                // The accessibility tree, mirrored into hidden DOM elements
+                // over the canvas. Does nothing off the web; there, egui's
+                // tree would otherwise be thrown away by eframe.
+                cc.egui_ctx.add_plugin(WebA11y::new(canvas_id));
+            })),
             // Three columns need more than eframe's default 640: the list and
             // the code take 200 and 40%, and the example gets what is left.
             #[cfg(not(target_arch = "wasm32"))]

--- a/examples/gallery/tests/a11y.rs
+++ b/examples/gallery/tests/a11y.rs
@@ -1,0 +1,128 @@
+//! Plan a11y A-3: no example grows a new widget that assistive technology
+//! cannot name.
+//!
+//! A widget with no name is read out as its role and nothing else ("button",
+//! "check box"), which is the one thing a screen reader cannot recover from.
+//! Every example is drawn once and every focusable node in its accessibility
+//! tree is checked for a name. The ones that have none today are listed in
+//! [`KNOWN_UNNAMED`] with the reason; the list is compared exactly, so it can
+//! only shrink — a new unnamed widget turns this red, and so does fixing one
+//! without crossing it off.
+
+use egui_kittest::Harness;
+use egui_kittest::kittest::NodeT as _;
+use gallery::{App, EXAMPLES};
+use react_egui::prelude::*;
+use react_egui_app::{root_id, root_style};
+
+/// Examples this test does not run.
+///
+/// `fetch` starts a real HTTP request the moment it is drawn (`use_future` +
+/// `ehttp`), which has no business in a unit test. The same reason keeps it out
+/// of `gallery.rs`.
+const SKIP: &[&str] = &["fetch"];
+
+/// The focusable nodes that have no name today, as `"<example>: <role>"` in
+/// the order the tree is walked.
+///
+/// None of these can be named through the elements as they stand:
+///
+/// - `TextInput`: `egui::TextEdit` writes no label into its AccessKit node at
+///   all. `hint_text` goes to `PlatformOutput` for the web screen reader, not
+///   to the node, and `<TextEdit>` has no name prop. Naming these needs the
+///   same treatment `<Button label>` got (`accesskit_node_builder`), or
+///   `Response::labelled_by` pointing at the label beside the field.
+/// - `form`'s `CheckBox` / `Slider` / `SpinButton` / `ComboBox`: the form names
+///   them with a label column (`<Field>`), which AccessKit expresses as a
+///   `labelled_by` relation that the elements do not expose. Their own `label`
+///   props draw the text, which would put the name on screen twice and desync
+///   the plain egui twin that the gallery renders beside it.
+/// - `escape-hatch`'s `ColorWell`: a raw `ui.color_edit_button_srgba`, which
+///   egui leaves unnamed.
+/// - `shader`'s `Unknown`: the `<Canvas>` leaf, which senses drags. It is a
+///   drawing surface, not a control; naming it needs a story for canvases in
+///   general (`docs/tasks/a11y/`).
+const KNOWN_UNNAMED: &[&str] = &[
+    "showcase: TextInput",
+    "todo: TextInput",
+    "form: TextInput",
+    "form: CheckBox",
+    "form: CheckBox",
+    "form: Slider",
+    "form: SpinButton",
+    "form: ComboBox",
+    "custom-hook: TextInput",
+    "custom-hook: TextInput",
+    "escape-hatch: ColorWell",
+    "shader: Unknown",
+    "list-10k: TextInput",
+];
+
+/// The same window as `gallery.rs`: a `ScrollArea` culls what it does not
+/// draw, and a culled widget is not in the tree to be checked.
+const WIDTH: f32 = 1280.0;
+const HEIGHT: f32 = 1000.0;
+
+fn harness<'a>(start: &'static str) -> Harness<'a, Store> {
+    Harness::builder()
+        .with_size(egui::vec2(WIDTH, HEIGHT))
+        .build_ui_state(
+            move |ui: &mut egui::Ui, store: &mut Store| {
+                store.begin_pass(ui.ctx());
+                {
+                    let store: &Store = store;
+                    let mut cx = Cx::new(store, ui, root_id());
+                    let view = rsx! { <App start={start}/> };
+                    cx.root_container(root_id(), root_style(), |cx| view.show(cx));
+                }
+                store.end_pass();
+            },
+            Store::new(),
+        )
+}
+
+#[test]
+fn every_focusable_widget_has_a_name() {
+    let mut unnamed = Vec::new();
+    let mut where_ = Vec::new();
+
+    for meta in EXAMPLES {
+        if SKIP.contains(&meta.name) {
+            continue;
+        }
+        let mut harness = harness(meta.name);
+        // `run_steps`, not `run`: an animated example (`shader`, `clock`) asks
+        // for a repaint every frame and `run` gives up when it never settles.
+        // Two passes is what the rest of the gallery tests take — one to lay
+        // out, one to draw at the sizes taffy worked out.
+        harness.run_steps(2);
+
+        for node in harness.root().children_recursive() {
+            let node = node.accesskit_node();
+            if !node.data().supports_action(egui::accesskit::Action::Focus) {
+                continue;
+            }
+            if node.label().is_some_and(|label| !label.trim().is_empty()) {
+                continue;
+            }
+            unnamed.push(format!("{}: {:?}", meta.name, node.role()));
+            where_.push(format!(
+                "{}: {:?} at {:?}",
+                meta.name,
+                node.role(),
+                node.bounding_box(),
+            ));
+        }
+    }
+
+    assert_eq!(
+        unnamed,
+        KNOWN_UNNAMED,
+        "the focusable widgets with no name are not the ones this test knows \
+         about.\n\nFound:\n{}\n\nA widget a screen reader cannot name is read \
+         out as its role and nothing else. Pass `label` (or `alt` on an \
+         `<Image>`), or, if the widget really cannot be named yet, add it to \
+         `KNOWN_UNNAMED` with the reason.",
+        where_.join("\n"),
+    );
+}

--- a/examples/list-10k/src/lib.rs
+++ b/examples/list-10k/src/lib.rs
@@ -163,7 +163,7 @@ fn Row(cx: &mut Cx, index: usize, name: &str, #[event] on_remove: ()) {
         <View direction="row" gap={8} align="center" w="100%" h={ROW_H}>
             <Text w={INDEX_W}>{format!("#{index}")}</Text>
             <Text grow={1.0}>{name}</Text>
-            <Button on_click={|| on_remove.emit(())}>"x"</Button>
+            <Button label="remove" on_click={|| on_remove.emit(())}>"x"</Button>
         </View>
     }
 }

--- a/examples/list-10k/src/plain.rs
+++ b/examples/list-10k/src/plain.rs
@@ -104,7 +104,11 @@ pub fn ui(ui: &mut egui::Ui, state: &mut PlainState) {
                     );
                     ui.label(name);
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if ui.button("x").clicked() {
+                        let button = ui.button("x");
+                        // `<Button label="remove">`, by hand.
+                        ui.ctx()
+                            .accesskit_node_builder(button.id, |node| node.set_label("remove"));
+                        if button.clicked() {
                             remove = Some(*i);
                         }
                     });

--- a/examples/list-10k/tests/list_10k.rs
+++ b/examples/list-10k/tests/list_10k.rs
@@ -88,7 +88,7 @@ fn removing_a_row_shortens_the_list() {
     // `ScrollArea` is swallowed before it reaches the row, and the button never
     // fires. Asking accessibility to activate it works.
     harness
-        .get_all_by_label("x")
+        .get_all_by_label("remove")
         .next()
         .expect("a remove button")
         .click_accesskit();
@@ -133,7 +133,7 @@ fn virtualising_keeps_the_behaviour() {
     assert!(harness.query_by_label("showing 13").is_some());
 
     harness
-        .get_all_by_label("x")
+        .get_all_by_label("remove")
         .next()
         .expect("a remove button")
         .click_accesskit();

--- a/examples/todo/src/lib.rs
+++ b/examples/todo/src/lib.rs
@@ -121,7 +121,8 @@ pub fn App(cx: &mut Cx) {
                         on_change={|_: bool| dispatch.send(Msg::Toggle(i))}
                     />
                     <Text grow={1.0}>{todo.text.as_str()}</Text>
-                    <Button on_click={|| dispatch.send(Msg::Remove(i))}>"x"</Button>
+                    // `label` is what a screen reader says; "x" is what is drawn.
+                    <Button label="remove" on_click={|| dispatch.send(Msg::Remove(i))}>"x"</Button>
                 </View>
             }
 

--- a/examples/todo/src/plain.rs
+++ b/examples/todo/src/plain.rs
@@ -83,7 +83,12 @@ pub fn ui(ui: &mut egui::Ui, state: &mut PlainState) {
                 // `<Text grow={1.0}>` before the button: here the button is
                 // put in a right-to-left `Ui` filling the rest of the row.
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.button("x").clicked() {
+                    let button = ui.button("x");
+                    // `<Button label="remove">`, by hand: an "x" is drawn but
+                    // "remove" is the name assistive technology reads.
+                    ui.ctx()
+                        .accesskit_node_builder(button.id, |node| node.set_label("remove"));
+                    if button.clicked() {
                         remove = Some(i);
                     }
                 });

--- a/examples/todo/tests/todo.rs
+++ b/examples/todo/tests/todo.rs
@@ -97,7 +97,7 @@ fn drive<S>(harness: &mut Harness<'_, S>) {
     );
 
     // Remove the first item.
-    harness.get_all_by_label("x").next().unwrap().click();
+    harness.get_all_by_label("remove").next().unwrap().click();
     harness.run();
     harness.run();
     assert!(

--- a/plan-overview.md
+++ b/plan-overview.md
@@ -25,7 +25,7 @@
 | PR5, PR6 | 6.5 | `docs/tasks/examples/` |
 | PR7 | 6.5(canvas) | `docs/tasks/canvas/` |
 
-フェーズ 8(公開準備)は PR4 の後に別途計画する。
+フェーズ 8(公開準備)は PR4 の後に別途計画する。web のアクセシビリティ(`docs/tasks/a11y/`)はその後の候補で、時期未定。
 
 ## フェーズ
 


### PR DESCRIPTION
## Summary

Web accessibility (`docs/tasks/a11y/`): react-egui apps on the web now expose their widget tree to assistive technology. egui already builds an AccessKit tree; eframe web drops it. An egui `Plugin` picks it up (no eframe fork) and a new `accesskit-web` crate mirrors it into hidden DOM elements over the canvas, Flutter-web style. Clicks, keys and slider changes from assistive tech go back to egui as `ActionRequest`s.

Verified in headless Chrome on the gallery: 72 mirrored nodes with roles, labels and rects; clicking a mirror button or pressing Enter changes the counter; setting the slider `<input>` moves egui's slider; Tab moves `aria-activedescendant` while real focus stays on the canvas. VoiceOver on macOS: all 8 checklist items pass (plan §4), so focus strategy F1 stands and no eframe fork is needed.

## Changes

- Added `crates/accesskit-web`: egui-independent adapter, ported from AccessKit's stalled `web-basics` branch to accesskit 0.24
  - Coordinates from `bounding_box()`, host scaled by `1/pixels_per_point`, `filter: opacity(0%)`, `pointer-events: none`
  - Sliders and text boxes are real `<input>` elements; everything else `div` + ARIA
  - DOM click / keydown / input / focusin → `ActionRequest` through `ActionHandler`
  - Focus F1: canvas keeps DOM focus and carries `aria-activedescendant` + `aria-owns` + `role="application"`; never calls `focus()` / `blur()`
  - `wasm-bindgen-test` suite (9 tests, run locally with `wasm-pack test --headless --chrome`)
- Added `react_egui_app::a11y::WebA11y`: egui `Plugin` that enables AccessKit, feeds the adapter from `output_hook` (skipping discarded passes), injects actions in `input_hook`; no-op off wasm32
  - Enabled in gallery `setup`; `?a11y-debug` outlines the mirror
- Added `Image.alt` and `Button.label` (`react-egui-elements`) with kittest
- Changed todo / list-10k `x` buttons to `label="remove"`
- Added gallery kittest `a11y.rs`: every example rendered, focusable nodes without a name pinned (13 known, list can only shrink)
- Added `docs/tasks/a11y/task.md` and `plan.md` (investigation, design, what changed during implementation); ARCHITECTURE 1 / 8, README

## Decisions

- No upstream proposal to AccessKit or eframe. `accesskit-web` and `WebA11y` stay in react-egui; switch if upstream ships an equivalent