### PR TITLE
feat: Canvas element, shader example, Options.setup (canvas task)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Commit messages and PR descriptions
+
+- Never add a Claude signature, `Co-Authored-By: Claude ...`, `Generated with Claude Code`, or any Claude session link to commit messages or PR descriptions in this repo. No exceptions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "react-egui",
  "react-egui-app",
  "react-egui-elements",
+ "shader",
  "showcase",
  "theme",
  "todo",
@@ -3342,6 +3343,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "shader"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "eframe",
+ "egui",
+ "egui-wgpu",
+ "egui_kittest",
+ "example-meta",
+ "log",
+ "react-egui",
+ "react-egui-app",
+ "react-egui-elements",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ egui_taffy = "0.14.0"
 # The version eframe 0.36.1 depends on. Pinned here so an example that builds
 # a render pipeline links against the same wgpu eframe does.
 wgpu = "30.0"
+# The same version eframe 0.36.1 pulls in, with the same (default) features, so
+# `Callback::new_paint_callback` speaks to the renderer eframe set up.
+egui-wgpu = "0.36.1"
+# For `#[derive(Pod, Zeroable)]` on the shader example's uniform block.
+bytemuck = { version = "1.25", features = ["derive"] }
 # Only the gallery uses it, for `syntax_highlighting::code_view_ui`. No
 # features: `syntect` would make the wasm much bigger and the built-in
 # highlighter is enough.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ eframe = "0.36.1"
 # `wgpu` and `snapshot` are intentionally left off: the tests run headless.
 egui_kittest = { version = "0.36.1", default-features = false }
 egui_taffy = "0.14.0"
+# The version eframe 0.36.1 depends on. Pinned here so an example that builds
+# a render pipeline links against the same wgpu eframe does.
+wgpu = "30.0"
 # Only the gallery uses it, for `syntax_highlighting::code_view_ui`. No
 # features: `syntect` would make the wasm much bigger and the built-in
 # highlighter is enough.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Every example but one runs in the browser in the [gallery](https://fand.github.i
 | `clock` | A stopwatch that asks for its own repaints, and an effect that cleans up after itself. | [#clock](https://fand.github.io/react-egui/#clock) | [lib.rs](examples/clock/src/lib.rs) | – |
 | `custom-hook` | Three hooks of your own, each called from two components that keep their own state. | [#custom-hook](https://fand.github.io/react-egui/#custom-hook) | [lib.rs](examples/custom-hook/src/lib.rs) | – |
 | `escape-hatch` | Four ways down to plain egui: a closure, a leaf, a painter, and a nested Cx. | [#escape-hatch](https://fand.github.io/react-egui/#escape-hatch) | [lib.rs](examples/escape-hatch/src/lib.rs) | – |
+| `shader` | A wgpu fragment shader in a `<Canvas>`, with a slider wired to its uniform. | [#shader](https://fand.github.io/react-egui/#shader) | [lib.rs](examples/shader/src/lib.rs) | – |
 | `list-10k` | Ten thousand rows: what drawing all of them costs, and what `<VirtualList>` saves. | [#list-10k](https://fand.github.io/react-egui/#list-10k) | [lib.rs](examples/list-10k/src/lib.rs) | [plain.rs](examples/list-10k/src/plain.rs) |
 | `shell` | Docked panels, a floating window, and an editor in what is left. | – (standalone) | [lib.rs](examples/shell/src/lib.rs) | – |
 | `layout` | Every flex and grid attribute `<View>` understands, one section each. | [#layout](https://fand.github.io/react-egui/#layout) | [lib.rs](examples/layout/src/lib.rs) | [plain.rs](examples/layout/src/plain.rs) |

--- a/crates/react-egui-app/Cargo.toml
+++ b/crates/react-egui-app/Cargo.toml
@@ -11,6 +11,13 @@ rust-version.workspace = true
 name = "react_egui_app"
 path = "src/lib.rs"
 
+# eframe 0.36's own default features include `wgpu` and not `glow`, so this
+# renders with wgpu already; glow is the opt-in one now. There is no feature
+# here to choose between them, because there is nothing to choose.
+#
+# The WebGL fallback comes for free with it: `eframe/wgpu` pulls
+# `egui-wgpu/default`, whose defaults include `wgpu/webgl`, so a browser
+# without WebGPU still gets a canvas. No direct `wgpu` dependency is needed.
 [dependencies]
 eframe = { workspace = true, features = ["persistence"] }
 egui.workspace = true

--- a/crates/react-egui-app/src/lib.rs
+++ b/crates/react-egui-app/src/lib.rs
@@ -44,6 +44,9 @@ pub fn root_style() -> react_egui::taffy::Style {
         .merge(&ItemStyle::default().w("100%").min_h("100%"))
 }
 
+/// What [`Options::setup`] holds: run once, when eframe is ready.
+pub type Setup = Box<dyn FnOnce(&eframe::CreationContext<'_>)>;
+
 /// How to run the app.
 pub struct Options {
     /// The native window title. Ignored on wasm.
@@ -64,6 +67,17 @@ pub struct Options {
     /// Everything else eframe accepts. Native only: wasm has no window.
     #[cfg(not(target_arch = "wasm32"))]
     pub native: eframe::NativeOptions,
+    /// Called once, as soon as eframe has a window and a render backend.
+    ///
+    /// This is where a wgpu pipeline is built and put into
+    /// `cc.wgpu_render_state`'s `renderer.write().callback_resources`, so that
+    /// a paint callback can find it again by type. egui's own `custom3d_wgpu`
+    /// demo does the same thing in the same place.
+    ///
+    /// It is a hole in the runner rather than a hook or a context value on
+    /// purpose: no wgpu type appears anywhere in the hook API, and an app that
+    /// does not draw with wgpu never sees one. Available on native and on wasm.
+    pub setup: Option<Setup>,
 }
 
 impl Default for Options {
@@ -75,6 +89,7 @@ impl Default for Options {
             canvas_id: String::from("react_egui_canvas"),
             #[cfg(not(target_arch = "wasm32"))]
             native: eframe::NativeOptions::default(),
+            setup: None,
         }
     }
 }
@@ -123,7 +138,12 @@ where
     V: View,
     F: FnMut(&mut Cx<'_, '_>) -> V,
 {
-    fn new(cc: &eframe::CreationContext<'_>, options: &Options, root: F) -> Self {
+    fn new(cc: &eframe::CreationContext<'_>, options: &mut Options, root: F) -> Self {
+        // First, before anything is drawn: a paint callback added on frame one
+        // has to find its pipeline already there.
+        if let Some(setup) = options.setup.take() {
+            setup(cc);
+        }
         let mut store = Store::new();
         if options.persist
             && let Some(storage) = cc.storage
@@ -194,13 +214,14 @@ mod platform {
     {
         let title = options.title.clone();
         let native = options.native.clone();
+        let mut options = options;
         let mut root = Some(root);
         eframe::run_native(
             &title,
             native,
             Box::new(move |cc| {
                 let root = root.take().expect("the app is created once");
-                Ok(Box::new(ReactApp::new(cc, &options, root)))
+                Ok(Box::new(ReactApp::new(cc, &mut options, root)))
             }),
         )
     }
@@ -229,6 +250,7 @@ mod platform {
             return Ok(());
         };
 
+        let mut options = options;
         let mut root = Some(root);
         wasm_bindgen_futures::spawn_local(async move {
             let result = eframe::WebRunner::new()
@@ -237,7 +259,7 @@ mod platform {
                     eframe::WebOptions::default(),
                     Box::new(move |cc| {
                         let root = root.take().expect("the app is created once");
-                        Ok(Box::new(ReactApp::new(cc, &options, root)))
+                        Ok(Box::new(ReactApp::new(cc, &mut options, root)))
                     }),
                 )
                 .await;
@@ -247,5 +269,15 @@ mod platform {
         });
         // The app keeps running in the browser's event loop.
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Options;
+
+    #[test]
+    fn setup_is_off_by_default() {
+        assert!(Options::default().setup.is_none());
     }
 }

--- a/crates/react-egui-elements/src/canvas.rs
+++ b/crates/react-egui-elements/src/canvas.rs
@@ -1,0 +1,57 @@
+//! [`Canvas`]: a rectangle taffy sizes and you paint yourself.
+
+use react_egui::layout::ItemStyle;
+use react_egui::prelude::*;
+
+/// A blank rectangle you draw into.
+///
+/// The element allocates the space taffy gave it and calls `paint` with the
+/// `Ui` and the rect it got. What goes in there is up to you: `ui.painter()`
+/// for lines and shapes, or a paint callback for a wgpu pipeline.
+///
+/// ```ignore
+/// <Canvas
+///     grow={1.0}
+///     sense={egui::Sense::drag()}
+///     on_drag={|d: egui::Vec2| *offset += d}
+///     paint={|ui: &mut egui::Ui, rect: egui::Rect| {
+///         ui.painter().circle_filled(rect.center(), 20.0, egui::Color32::RED);
+///     }}
+/// />
+/// ```
+///
+/// The size comes from the style, not the content (`leaf_fill`), so give it
+/// `grow` or a `w` / `h`; with neither it fills the window.
+///
+/// `sense` is what egui asks of the rect, and it decides which events can fire:
+/// the default `hover()` gives `on_hover` only, `drag()` (or `click_and_drag()`)
+/// is needed for `on_drag`.
+///
+/// This element knows nothing about wgpu. A shader is drawn by pushing
+/// `egui_wgpu::Callback::new_paint_callback(rect, ..)` onto `ui.painter()` from
+/// inside `paint`, which keeps the graphics API on the caller's side.
+#[component]
+pub fn Canvas(
+    cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,
+    #[prop(default = egui::Sense::hover())] sense: egui::Sense,
+    // The bound is spelled out rather than elided, as in `VirtualList`:
+    // `#[component]` rewrites an elided lifetime in a prop to the props
+    // struct's own, and the `Ui` here is the leaf's, not the props'.
+    paint: impl for<'a> FnOnce(&'a mut egui::Ui, egui::Rect),
+    #[event] on_drag: egui::Vec2,
+    #[event] on_hover: egui::Pos2,
+) {
+    let response = cx.leaf_fill(&style, move |ui| {
+        let (rect, response) = ui.allocate_exact_size(ui.available_size(), sense);
+        paint(ui, rect);
+        response
+    });
+
+    if response.dragged() {
+        on_drag.emit(response.drag_delta());
+    }
+    if let Some(pos) = response.hover_pos() {
+        on_hover.emit(pos);
+    }
+}

--- a/crates/react-egui-elements/src/lib.rs
+++ b/crates/react-egui-elements/src/lib.rs
@@ -11,12 +11,14 @@
 //!   re-enter the tree with the inner `Ui`.
 //!
 //! Plus [`Suspense`](suspense::Suspense), which draws a fallback until the
-//! `use_future`s below it are ready.
+//! `use_future`s below it are ready, and [`Canvas`](canvas::Canvas), a leaf
+//! taffy sizes and the caller paints.
 //!
 //! Every element accepts the layout attributes of
 //! [`ItemStyle`](react_egui::ItemStyle) through a `style` prop, which `rsx!`
 //! fills in from `w=` / `grow=` / `p=` and friends.
 
+pub mod canvas;
 pub mod containers;
 pub mod suspense;
 pub mod view;
@@ -28,6 +30,7 @@ pub mod widgets;
 /// The event enums have to be in scope wherever `<Button on_click=../>` is
 /// written, because that is the name the fused closure matches on.
 pub mod prelude {
+    pub use crate::canvas::{Canvas, CanvasEvent};
     pub use crate::containers::{
         CentralPanel, Collapsing, Frame, Grid, Horizontal, Panel, Row, ScrollArea, Side, Vertical,
         Window,

--- a/crates/react-egui-elements/tests/canvas.rs
+++ b/crates/react-egui-elements/tests/canvas.rs
@@ -1,0 +1,162 @@
+//! Plan 3.3: `<Canvas>` gets its rect from taffy and reports pointer events.
+
+mod common;
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use common::run_app;
+use egui_kittest::Harness;
+use egui_kittest::kittest::Queryable as _;
+use react_egui::prelude::*;
+use react_egui_elements::prelude::*;
+
+/// The rect `paint` was last called with.
+type Painted = Rc<Cell<Option<egui::Rect>>>;
+
+/// Draw `app` in a 300x300 window and hand the test its harness.
+fn harness_for(app: impl Fn(&mut Cx<'_, '_>) + 'static) -> Harness<'static, Store> {
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(300.0, 300.0))
+        .build_ui_state(
+            move |ui, store: &mut Store| {
+                run_app(ui, store, |cx| app(cx));
+            },
+            Store::new(),
+        );
+    harness.run();
+    harness
+}
+
+#[test]
+fn the_painted_rect_is_the_size_the_style_asks_for() {
+    let painted: Painted = Rc::default();
+    let seen = Rc::clone(&painted);
+    let _harness = harness_for(move |cx| {
+        let seen = Rc::clone(&seen);
+        rsx! {
+            <View direction="column" w={300.0} h={300.0}>
+                <Canvas
+                    w={120.0}
+                    h={60.0}
+                    paint={move |_ui: &mut egui::Ui, rect: egui::Rect| seen.set(Some(rect))}
+                />
+            </View>
+        }
+        .show(cx);
+    });
+
+    let rect = painted.get().expect("paint should have run");
+    assert!(
+        (rect.width() - 120.0).abs() < 1.0 && (rect.height() - 60.0).abs() < 1.0,
+        "w/h should reach the rect: {rect:?}",
+    );
+}
+
+#[test]
+fn grow_takes_the_space_the_others_leave() {
+    let painted: Painted = Rc::default();
+    let seen = Rc::clone(&painted);
+    let harness = harness_for(move |cx| {
+        let seen = Rc::clone(&seen);
+        rsx! {
+            <View direction="column" w={300.0} h={280.0} gap={0}>
+                <Text>"header"</Text>
+                <Canvas
+                    grow={1.0}
+                    paint={move |_ui: &mut egui::Ui, rect: egui::Rect| seen.set(Some(rect))}
+                />
+            </View>
+        }
+        .show(cx);
+    });
+
+    let rect = painted.get().expect("paint should have run");
+    let header = harness.get_by_label("header").rect();
+    assert!(
+        (rect.width() - 300.0).abs() < 1.0,
+        "the column is 300 wide: {rect:?}",
+    );
+    assert!(
+        rect.height() > 280.0 - header.height() - 2.0,
+        "grow should take the rest of the 280: {rect:?} under {header:?}",
+    );
+    assert!(
+        rect.top() >= header.bottom() - 1.0,
+        "the canvas sits below the header: {rect:?} {header:?}",
+    );
+}
+
+#[test]
+fn dragging_reports_the_delta() {
+    let painted: Painted = Rc::default();
+    let dragged: Rc<Cell<egui::Vec2>> = Rc::default();
+    let seen = Rc::clone(&painted);
+    let moved = Rc::clone(&dragged);
+    let mut harness = harness_for(move |cx| {
+        let seen = Rc::clone(&seen);
+        let moved = Rc::clone(&moved);
+        rsx! {
+            <View direction="column" w={300.0} h={300.0}>
+                <Canvas
+                    grow={1.0}
+                    sense={egui::Sense::drag()}
+                    on_drag={|d: egui::Vec2| moved.set(moved.get() + d)}
+                    paint={move |_ui: &mut egui::Ui, rect: egui::Rect| seen.set(Some(rect))}
+                />
+            </View>
+        }
+        .show(cx);
+    });
+
+    let center = painted.get().expect("paint should have run").center();
+    harness.hover_at(center);
+    harness.drag_at(center);
+    harness.run();
+    harness.hover_at(center + egui::vec2(30.0, 20.0));
+    harness.run();
+    harness.drop_at(center + egui::vec2(30.0, 20.0));
+    harness.run();
+
+    let delta = dragged.get();
+    assert!(
+        (delta.x - 30.0).abs() < 1.0 && (delta.y - 20.0).abs() < 1.0,
+        "the drag delta should add up to the pointer's move: {delta:?}",
+    );
+}
+
+#[test]
+fn hovering_reports_the_pointer_position() {
+    let painted: Painted = Rc::default();
+    let hovered: Rc<Cell<Option<egui::Pos2>>> = Rc::default();
+    let seen = Rc::clone(&painted);
+    let at = Rc::clone(&hovered);
+    let mut harness = harness_for(move |cx| {
+        let seen = Rc::clone(&seen);
+        let at = Rc::clone(&at);
+        rsx! {
+            <View direction="column" w={300.0} h={300.0}>
+                <Canvas
+                    grow={1.0}
+                    on_hover={|pos: egui::Pos2| at.set(Some(pos))}
+                    paint={move |_ui: &mut egui::Ui, rect: egui::Rect| seen.set(Some(rect))}
+                />
+            </View>
+        }
+        .show(cx);
+    });
+
+    let rect = painted.get().expect("paint should have run");
+    assert!(hovered.get().is_none(), "nothing hovered yet");
+
+    let pos = rect.center();
+    harness.hover_at(pos);
+    harness.run();
+
+    let seen = hovered.get().expect("the pointer is over the canvas");
+    assert!(
+        (seen - pos).length() < 1.0,
+        "the reported position is the pointer's: {seen:?} vs {pos:?}",
+    );
+    assert!(rect.contains(seen), "and it is inside the rect: {rect:?}");
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -368,7 +368,7 @@ examples/              counter, todo (use_reducer + use_persisted), layout, fetc
 3. ルートの `Cx` を作り、`root(cx)` が返した `View` を `cx.root_container(..)`(`direction: column`、`w` は `100%`、`min_h` は `100%`、`reserve_available_space`)の中で `show` する。ネストしたコンテナは幅だけを確保するので、ルートだけが高さも取る。この id とスタイルは `react_egui_app::root_id()` / `root_style()` として公開し、テストや自作ランナーが同じ枠を再現できるようにする。
 4. `store.end_pass()`。
 
-`Options` は `title` / `max_passes`(既定 3、`ctx.options_mut` で明示設定。5.3 参照)/ `persist` / `canvas_id`(wasm)/ `native`(native のみ)を持つ。`App::save` が `store.save_persisted()` を `Storage` の `"react_egui"` キーに書き、`CreationContext::storage` から `load_persisted` する。wasm では `cfg(target_arch = "wasm32")` で `WebRunner` を `wasm_bindgen_futures::spawn_local` に載せ、canvas は `canvas_id` で引く。
+`Options` は `title` / `max_passes`(既定 3、`ctx.options_mut` で明示設定。5.3 参照)/ `persist` / `canvas_id`(wasm)/ `native`(native のみ)/ `setup` を持つ。`setup: Option<Box<dyn FnOnce(&eframe::CreationContext)>>` は eframe が窓と描画バックエンドを用意した直後に 1 回だけ呼ぶ穴で、`ReactApp::new` の先頭で実行する。wgpu の pipeline を作って `cc.wgpu_render_state` の `renderer.write().callback_resources` に置く場所である(egui 公式 demo の `custom3d_wgpu` と同じ形)。hook や context 経由で `RenderState` を配る案は採らない。wgpu の型は hook API のどこにも出さず、wgpu を使わないアプリは一生見ない、という線を引くためである。native と wasm の両方にある。`App::save` が `store.save_persisted()` を `Storage` の `"react_egui"` キーに書き、`CreationContext::storage` から `load_persisted` する。wasm では `cfg(target_arch = "wasm32")` で `WebRunner` を `wasm_bindgen_futures::spawn_local` に載せ、canvas は `canvas_id` で引く。
 
 `root` は毎パス呼ばれ、返す `View` は `root` の中で作ったものを借用できない(hook の guard を借りた `rsx!` はローカルを借用した値を返すことになる)。hooks はコンポーネントに置き、ルートは `|_cx| rsx!{ <App/> }` の形にする。
 
@@ -376,7 +376,7 @@ egui は 0.36 系に固定する。egui 0.35 以降 `eframe::App::ui` が `&mut 
 
 ## 8. プラットフォーム
 
-- native / wasm / Android: eframe。wasm は trunk でビルドする。
+- native / wasm / Android: eframe。wasm は trunk でビルドする。描画バックエンドは wgpu。**eframe 0.36 の既定 feature には `wgpu` が入っていて `glow` は入っていない**(0.35 までとは逆)ので、何もしなくても wgpu で描かれる。glow の方が opt-in になったため、選択のための feature は置かない。web は WebGPU 非対応のブラウザのために WebGL へ落ちる。`eframe/wgpu` → `egui-wgpu/default` → `wgpu/webgl` と伝播するので、こちらで `wgpu` を直接依存に取る必要は無い。
 - iOS: eframe は未対応(emilk/egui#3117 が open)。`egui-winit` + `egui-wgpu` の薄いランナーを `react-egui-app` 内に書く。ビルドは cargo-mobile2。
 - ライブラリ本体は `&mut egui::Ui` しか触らないので、プラットフォーム対応はランナー層とタッチ / IME の調整に閉じる。
 - 非同期の実行機構は core の `task::spawn` に閉じる(4 章「`use_future` の詳細」)。iOS / Android は native と同じスレッド経路を使う。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -325,6 +325,7 @@ Flexbox / Grid を一級市民にするため egui_taffy を採用する(0.14、
 | レイアウト | `View`(`display` / `direction` / `wrap` / `justify` / `align` / `align_content` / `gap` / `cols`)、`Text`(`size` / `color` / `strong` / `wrap`) |
 | ウィジェット | `Button`(`enabled`, `on_click`)、`Label`(`wrap`)、`TextEdit`(`bind` / `multiline` / `hint` / `desired_width` / `rows`, `on_change` / `on_submit`)、`Checkbox`(`bind` / `label`, `on_change`)、`Slider<T: Numeric>`(`bind` / `range` / `label`, `on_change`)、`ComboBox`(`bind` / `options` / `label`, `on_change`)、`Image`(`source` / `fit`)、`Separator`(`vertical`) |
 | コンテナ | `ScrollArea`、`VirtualList`(`rows` / `row_h` / `render`)、`Collapsing`、`Frame`、`Window`(`title` / `open` / `resizable` / `default_pos` / `default_size`)、`Panel`(`side`)、`CentralPanel`、`Vertical`、`Horizontal`、`Grid` + `row()` |
+| 描画 | `Canvas`(`sense` / `paint`, `on_drag` / `on_hover`。taffy がくれた矩形をそのまま渡す leaf) |
 | 非同期 | `Suspense`(`fallback: impl View`、`shares_ui`。中の `use_future` が 1 つでも `Pending` なら children の代わりに `fallback` を描く。5.8) |
 
 `TextEdit` は taffy の中(`Cx::in_taffy()`)ではノードを埋める。単行は `desired_width` をノードの幅にし、`multiline` は `ui.add_sized(ui.available_size(), ..)` で縦横とも埋める(`desired_rows` だと行単位にしか合わず、端数がノードからはみ出す)。`grow` や `w` で広げたノードの中に egui 既定の 280pt / 4 行で描かれると残りが空くためである。`desired_width` / `rows` を明示した場合はそちらが勝つ。`Slider` / `ComboBox` / `Button` は今のところ伸びない(それぞれ `spacing.slider_width` / `spacing.combo_width` / 内容の幅のまま)。
@@ -334,6 +335,8 @@ Flexbox / Grid を一級市民にするため egui_taffy を採用する(0.14、
 egui 標準のコンテナのうち、親から場所を切り取るもの(`Panel` / `CentralPanel`)と、親の `Ui` に依存するもの(`Grid` の行区切り)は、`rsx!` が要素ごとに `Ui::push_id` で子 `Ui` を作ることの影響を受ける。行区切りは要素ではなく `{row()}`(`{expr}` ノードはスコープされない)として提供する。これらは `#[component(shares_ui)]` を付けて親の surface をそのまま引き継ぐ。
 
 **パネルが場所を切り取る先は「最も近い egui の `Ui`」、つまり今の taffy ツリーを開始した `Ui` である。** 間に `<View>` が何段あっても飛ばす。taffy モードのとき `Panel` / `CentralPanel` は `cx.leaf` を使わず `cx.ui()` に対して `show_inside` する。leaf を作ってしまうとパネルは自分専用の小さなノードの中を切り取ることになり、兄弟に並べた 4 つのパネルが全部同じ角に重なる。ランナーの下ではこの `Ui` は窓そのものなので、「パネルはアプリのルートで使う」は自動的に成り立つ。裏返しの帰結として、`<View>` の奥に書いた `<Panel>` はその行の一部ではなく窓の端まで飛ぶ。これは docking の意味であって不具合ではない(`examples/shell`)。`ScrollArea` は children をそのまま全部描く。長いリストは `VirtualList` を使う。`rows` と `row_h` を受け取り、`render(cx, i)` を「見えている行」にだけ呼ぶ(中身は `egui::ScrollArea::show_rows`)。行は `cx.scope(i, ..)` の中で描かれるので、`for` + `key={i}` と同じく行ごとに hook を持てる。全行が同じ高さであることが条件である。`render` の bound は `impl for<'a, 's, 'u> FnMut(&'a mut Cx<'s, 'u>, usize)` と明示して書く。`#[component]` は prop の省略ライフタイムを props 構造体のものに書き換えるので、省略形(`impl FnMut(&mut Cx, usize)`)はコンパイルできない。
+
+`Canvas` は自分では何も描かない leaf である。`leaf_fill` で taffy がくれた大きさを `ui.allocate_exact_size(ui.available_size(), sense)` で確保し、`paint(ui, rect)` を呼ぶだけで、中身は呼び出し側が `ui.painter()` に積む(線や図形でも、`egui_wgpu::Callback::new_paint_callback(rect, ..)` でも)。elements は egui-wgpu に依存しない。`sense` は既定が `Sense::hover()` で、`on_hover`(矩形内のポインタ位置)はそのまま、`on_drag`(`drag_delta`)には `Sense::drag()` が要る。閉包 prop の名前は `on_paint` ではなく `paint` である。`rsx!` は `on_` で始まる属性を全てイベント enum の variant として扱うので、`on_` 始まりの普通の prop は書けない(`VirtualList` の `render` と同じ命名)。bound は `impl for<'a> FnOnce(&'a mut egui::Ui, egui::Rect)` と明示する(`VirtualList` と同じ理由)。
 
 `Suspense` も同じ理由で `shares_ui` である。自分では何も描かず children と `fallback` を親にそのまま流すので、`<View>` の中に置けば children が親の taffy ツリーの子になる。
 

--- a/docs/tasks/canvas/plan.md
+++ b/docs/tasks/canvas/plan.md
@@ -1,0 +1,121 @@
+# プラン: canvas
+
+タスク定義は [task.md](task.md)。設計の根拠は [docs/ARCHITECTURE.md](../../ARCHITECTURE.md)。本書は [docs/tasks/examples/plan.md](../examples/plan.md) 3 章(PR C)を切り出したもので、3.1(`wgpu` feature)は不要と判明したので落とし、3.2 は実装済み。実装中にここから外れる判断をした場合は本書を更新し、設計上の意味があれば ARCHITECTURE.md も更新する。
+
+## 0. 全体
+
+1 PR。触るのは `react-egui-elements`(`Canvas`)、`examples/shader`、`examples/gallery`(登録と `setup`)、`examples/escape-hatch`(painter 節の置き換え、任意)、README、ARCHITECTURE。`react-egui-app` は済み(`Options.setup`)。core は無変更。
+
+前提の訂正: eframe 0.36 は既定で wgpu(glow は opt-in)、WebGL fallback は `egui-wgpu/default` 経由で入っている。backend を選ぶ feature は置かない。
+
+## 1. 設計(examples plan 3.2〜3.5 より)
+
+### 3.2 `Options.setup`
+
+```rust
+pub struct Options {
+    ..
+    /// eframe が起動した直後に 1 回呼ぶ。wgpu の pipeline を作って
+    /// `render_state.renderer.write().callback_resources` に置く場所。
+    pub setup: Option<Box<dyn FnOnce(&eframe::CreationContext<'_>)>>,
+}
+```
+
+`ReactApp::new` の先頭で呼ぶ。egui 公式 demo(`custom3d_wgpu`)と同じ形。`use_context` で `RenderState` を配る案は slot を作る手間に対して得るものが少ないので採らない。hook にも context にも wgpu の型は出ない。
+
+### 3.3 `<Canvas>` 要素(`react-egui-elements`)
+
+```rust
+#[component]
+pub fn Canvas(
+    cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,
+    #[prop(default)] sense: egui::Sense,          // 既定 hover
+    on_paint: impl FnOnce(&mut egui::Ui, egui::Rect),
+    #[event] on_drag: egui::Vec2,                  // drag_delta
+    #[event] on_hover: egui::Pos2,                 // 矩形内のポインタ位置
+)
+```
+
+- `cx.leaf_fill(&style, |ui| { let (rect, resp) = ui.allocate_exact_size(ui.available_size(), sense); on_paint(ui, rect); resp })`。`leaf_fill` なので大きさは taffy が決める(`w h` / `grow`)。
+- elements は egui-wgpu に依存しない。callback を `ui.painter().add(..)` するのは example 側。`egui::Painter` で線を引くだけの用途(plot 等)にも使える。
+- テスト(kittest、headless): `on_paint` に渡る `rect` が `w h` で指定した大きさになる。`grow={1.0}` で残り全部になる。drag で `on_drag` が発火する。
+
+### 3.4 `examples/shader`
+
+```
+examples/shader/src/
+  lib.rs      App: <Canvas grow> + Slider(speed) + Checkbox(pause) + ComboBox(shader 選択)
+  gpu.rs      setup(cc)、ShaderResources、ShaderCallback: CallbackTrait
+  shader.wgsl fullscreen triangle + fragment。uniform { time, resolution, mouse, speed }
+  main.rs     run(Options { setup: Some(Box::new(gpu::setup)), .. }, ..)
+```
+
+```rust
+#[component]
+fn App(cx: &mut Cx) {
+    let mut speed = use_state(cx, || 1.0f32);
+    let mut paused = use_state(cx, || false);
+    let mut mouse = use_state(cx, || egui::Vec2::ZERO);
+    let time = cx.ui().input(|i| i.time) as f32;
+    if !*paused {
+        cx.ui().ctx().request_repaint();
+    }
+    rsx! {
+        <View direction="column" gap={8} grow={1.0}>
+            <Canvas
+                grow={1.0}
+                on_drag={|d: egui::Vec2| *mouse += d}
+                on_paint={|ui: &mut egui::Ui, rect| {
+                    ui.painter().add(egui_wgpu::Callback::new_paint_callback(
+                        rect,
+                        gpu::ShaderCallback { time: time * *speed, mouse: *mouse },
+                    ));
+                }}
+            />
+            <View direction="row" gap={8} align="center">
+                <Slider bind={speed.bind()} range={0.0..=4.0} label="speed"/>
+                <Checkbox bind={paused.bind()} label="pause"/>
+            </View>
+        </View>
+    }
+}
+```
+
+- `ShaderCallback::prepare` で `queue.write_buffer` に uniform を書き、`paint` で 3 頂点を描く。viewport / scissor は egui-wgpu が `rect` に合わせる。
+- `state` がそのまま uniform に流れるのが見せ所。`Slider` の `bind` → `speed` → uniform。
+- `ShaderResources` は `callback_resources`(`TypeMap`)に型で置く。gallery で他の example と同居しても型が違えば衝突しない。
+- 多重パス: 捨てられたパスの shape は egui が破棄する。callback が二重に走ることはない。
+- gallery は `react-egui-app/wgpu` を on にし、`setup` で `shader::gpu::setup(cc)` を呼ぶ。
+- 生 egui 版は作らない(wgpu 部分は同じコードになり、差が出ない)。
+
+### 3.5 テスト
+
+| # | 内容 |
+|---|---|
+| C-1 | `Canvas` の `rect` と `on_drag`(3.3、headless) |
+| C-2 | shader: Slider を動かすと `speed` が変わり、pause で `request_repaint` が止まる(`harness` の repaint 要求を見る) |
+| C-3 | snapshot(feature `snapshot`、ローカルのみ): time を 0 に固定して 1 枚。kittest の `WgpuTestRenderer` の render state に `setup` 相当を流し込めるかは 5 章 |
+
+
+## 2. 手順
+
+1. `<Canvas>` + kittest(1 の 3.3)。ARCHITECTURE 6 章。コミット。
+2. `examples/shader`(native → trunk)。gallery に登録し、gallery の `Options.setup` で `shader::gpu::setup(cc)` を呼ぶ。README の表。コミット。
+3. escape-hatch の painter 節を `<Canvas>` に置き換える(1 行で済む場合のみ)。コミット。
+4. snapshot(C-3)を試す。無理なら 3 章に理由を書く。PR。
+
+## 3. 実装で判明した差分
+
+### 手順 6: `Options.setup`(と `wgpu` feature を置かない判断)
+
+**3.1 の前提が間違っていた。「eframe は default(glow)のまま」は eframe 0.36 では成り立たない。** eframe 0.36.1 の `default` feature は `["accesskit", "default_fonts", "links", "wayland", "web_screen_reader", "wgpu", "winit/default", "x11"]` で、**`glow` は入っていない**。`Renderer::Glow` は `glow` feature が無いと存在すらせず、`Renderer::default()` は `Wgpu` を返す。つまり **このリポジトリは最初から wgpu で描いていた**。0.35 までとは逆で、今は glow の方が opt-in である。
+
+そのため **`wgpu` feature は置かない**。一度は `wgpu = ["eframe/wgpu"]` を足したが、今日の eframe では何も変えない feature であり、API の雑音にしかならない。5 章の「wgpu を唯一の backend にするか」は、eframe 側が先に決めてくれた形になる。glow で動かしたい人は `eframe/glow` を明示する話で、それはこの crate の仕事ではない。判断の根拠は `crates/react-egui-app/Cargo.toml` のコメントと ARCHITECTURE 8 章に残した。
+
+**WebGL fallback も何もしなくても入っている。** `eframe/wgpu` → `egui-wgpu/default` → `wgpu/webgl`。3.1 の「wasm は `wgpu` の `webgl` feature を on にする」は不要だった。`[workspace.dependencies]` には `wgpu = "30.0"`(eframe 0.36.1 が使う版)を pin だけしてある。shader example が pipeline を組むときに同じ wgpu へリンクするため。
+
+**`Options.setup`** は 3.2 のとおり足した。型は `Option<Setup>`、`pub type Setup = Box<dyn FnOnce(&eframe::CreationContext<'_>)>`(clippy の `type_complexity` が生の型を蹴るので別名にした。API としてもこちらが読みやすい)。`ReactApp::new` の先頭で `take()` して呼ぶ。1 フレーム目に paint callback が追加されうるので、store を作るより前に走らせる。`ReactApp::new` の `options` 引数を `&Options` から `&mut Options` にし、native / wasm どちらの起動閉包も `options` を move で持って `take` する(閉包はどちらも 1 回しか呼ばれない)。
+
+- テストは `crates/react-egui-app/src/lib.rs` の `#[cfg(test)] mod tests` に 1 つ、`setup` の既定が `None` であること。kittest は eframe を動かせないので、実際に wgpu で描かれることの確認は目視(`RUST_LOG=eframe=info`)に委ねる。
+- ARCHITECTURE 7 章(`Options` の一覧と `setup`)と 8 章(バックエンドと WebGL fallback)を更新。

--- a/docs/tasks/canvas/plan.md
+++ b/docs/tasks/canvas/plan.md
@@ -113,6 +113,22 @@ fn App(cx: &mut Cx) {
 
 `#[prop(default = egui::Sense::hover())]` は通った(task.md の「通らなければ `Option<egui::Sense>`」は不要)。イベントは `Response` から発火する: `dragged()` なら `on_drag(drag_delta())`、`hover_pos()` があれば `on_hover(pos)`。kittest は `crates/react-egui-elements/tests/canvas.rs` に 4 本(`w`/`h` どおりの rect、`grow` で残り全部、drag の delta、hover の位置)。イベントハンドラは `move` で書けない(融合された閉包が `FnMut` なので、テストの `Rc` は借用で捕まえる)。
 
+### 手順 2: `examples/shader`
+
+**`<Canvas grow={1.0}>` だけでは足りない。`h={0.0}` と併記する。** `leaf_fill` は egui_taffy に `infinite: Vec2b::TRUE` を渡すので、max-content の測定値がルートの高さそのものになる(`egui_taffy` の `compute_layout_with_measure` の閉包)。ランナーのルートは `min_h: 100%` で高さは `auto` なので、列の高さが「canvas 全部 + 他の子」になり、Slider と Checkbox が窓の下にはみ出す(520px の窓で y=588)。`basis={0.0}` / `min_h={0.0}` / 親の `h="100%"` はどれも効かない(auto の親に対する % は auto に落ちる)。効いたのは flexbox の定石どおり `h={0.0}` + `grow={1.0}`。example にコメントを書き、テスト(`the_controls_stay_below_the_canvas`)で押さえた。3.3 の kittest が気づけなかったのは、どちらのケースも親に `h` を明示していたため。
+
+**wgpu 30 の API は 3.4 のスケッチと少し違う。** `PipelineLayoutDescriptor` は `push_constant_ranges` ではなく `immediate_size: u32`、`bind_group_layouts` は `&[Option<&BindGroupLayout>]`、`RenderPipelineDescriptor` は `multiview` ではなく `multiview_mask`。
+
+**uniform に `speed` も入れた**(3.4 は `{ time, mouse }` だけ)。pause 中も Slider が効いていることが目で分かるよう、色を `speed` で振る。レイアウトは `{ time, speed, resolution, mouse }` + 8 バイトの尾部 padding = 32 バイト(`vec2<f32>` は uniform block で 8 バイト境界)。`bytemuck` の `Pod`/`Zeroable` derive を使うので `[workspace.dependencies]` に `bytemuck` を足した。`egui-wgpu = "0.36.1"` も同様(eframe と同じ版・同じ feature)。
+
+**fragment の `@builtin(position)` はフレームバッファ全体の座標で、rect の左上が原点ではない。** viewport をずらしても fragcoord は動かないので、clip 座標を varying で渡して -1..1 を作る。rect の位置を uniform に足す必要はない。
+
+**テスト(C-2)は `harness.ctx.has_requested_repaint()` を見る。** アニメーション中は毎フレーム repaint を要求するので `run()` は max steps で panic する。clock と同じく `step()` を使い、pause 後だけ `run_ok()` で落ち着かせる。paint callback は painter に積まれるだけで、kittest の既定レンダラは callback を実行しないため headless で安全(`gpu::setup` も呼ばれない)。
+
+**snapshot(C-3)は shader では撮らない。** `WgpuTestRenderer` の `RenderState` に `setup` 相当を差し込む口がなく、`ShaderResources` が見つからないので何も描かれない。加えて毎フレーム repaint を要求するので絵が安定しない。理由は `examples/gallery/tests/snapshots.rs` にも書いた。目視のみ。
+
+**ComboBox(shader 選択)は入れない。** 3.4 のファイル構成コメントにはあったが、shader を 1 本に絞った方が「state → uniform」の線が見やすい。
+
 ### 手順 6: `Options.setup`(と `wgpu` feature を置かない判断)
 
 **3.1 の前提が間違っていた。「eframe は default(glow)のまま」は eframe 0.36 では成り立たない。** eframe 0.36.1 の `default` feature は `["accesskit", "default_fonts", "links", "wayland", "web_screen_reader", "wgpu", "winit/default", "x11"]` で、**`glow` は入っていない**。`Renderer::Glow` は `glow` feature が無いと存在すらせず、`Renderer::default()` は `Wgpu` を返す。つまり **このリポジトリは最初から wgpu で描いていた**。0.35 までとは逆で、今は glow の方が opt-in である。

--- a/docs/tasks/canvas/plan.md
+++ b/docs/tasks/canvas/plan.md
@@ -107,6 +107,12 @@ fn App(cx: &mut Cx) {
 
 ## 3. 実装で判明した差分
 
+### 手順 1: `Canvas`
+
+**閉包 prop の名前は `on_paint` ではなく `paint` にした。** `rsx!` は属性名が `on_` で始まればそれをイベントハンドラと見なし、`<要素名>Event` の variant(`on_paint` → `CanvasEvent::Paint`)を探しに行く(`crates/react-egui-macros/src/rsx/mod.rs` の属性の振り分け)。つまり `on_` で始まる普通の prop は rsx! からは書けない。逃げ道は「core を変える」か「名前を変える」かで、core 無変更が前提なので後者を採った。`VirtualList` の `render` と同じ命名になり、`on_*` = イベント、それ以外 = prop という読み方も保てる。3.4 の shader example のコードも `paint={..}` になる。
+
+`#[prop(default = egui::Sense::hover())]` は通った(task.md の「通らなければ `Option<egui::Sense>`」は不要)。イベントは `Response` から発火する: `dragged()` なら `on_drag(drag_delta())`、`hover_pos()` があれば `on_hover(pos)`。kittest は `crates/react-egui-elements/tests/canvas.rs` に 4 本(`w`/`h` どおりの rect、`grow` で残り全部、drag の delta、hover の位置)。イベントハンドラは `move` で書けない(融合された閉包が `FnMut` なので、テストの `Rc` は借用で捕まえる)。
+
 ### 手順 6: `Options.setup`(と `wgpu` feature を置かない判断)
 
 **3.1 の前提が間違っていた。「eframe は default(glow)のまま」は eframe 0.36 では成り立たない。** eframe 0.36.1 の `default` feature は `["accesskit", "default_fonts", "links", "wayland", "web_screen_reader", "wgpu", "winit/default", "x11"]` で、**`glow` は入っていない**。`Renderer::Glow` は `glow` feature が無いと存在すらせず、`Renderer::default()` は `Wgpu` を返す。つまり **このリポジトリは最初から wgpu で描いていた**。0.35 までとは逆で、今は glow の方が opt-in である。

--- a/docs/tasks/canvas/task.md
+++ b/docs/tasks/canvas/task.md
@@ -1,0 +1,49 @@
+# タスク: canvas(PR7 = フェーズ 6.5 の残り、実装は停止中)
+
+## 目的
+
+コンポーネントの中で wgpu の shader アニメーションを描けるようにする。そのために必要な最小の口を開ける: `<Canvas>` 要素(taffy から矩形をもらい `on_paint(ui, rect)` を呼ぶ leaf)と、`examples/shader`(fullscreen triangle + fragment shader、state が uniform に流れる)。ランナー側の口 `Options.setup`(起動時に 1 回、pipeline を作って `callback_resources` に置く場所)は済んでいる。
+
+もとは [docs/tasks/examples/](../examples/task.md) の PR C だった。PR A(#4)/ PR B(#6 → #8)が先にマージされ、C は `Options.setup` だけ実装した時点で作業を止めたので、残りを独立タスクに切り出した。core(`react-egui`、`react-egui-macros`)には手を入れない。
+
+## 現状
+
+- 済: `Options.setup: Option<Setup>`(`react-egui-app`)。`ReactApp::new` の先頭で呼ぶ。`wgpu = "30.0"` を workspace に pin。ARCHITECTURE 7 / 8 章更新。
+- 済(判断): `wgpu` feature は置かない。eframe 0.36 は既定が wgpu で glow が opt-in。WebGL fallback も `egui-wgpu/default` 経由で入っている。
+- 未: `<Canvas>` 要素、`examples/shader`、gallery への登録、テスト、README。
+
+## スコープ
+
+### 含む
+
+- `<Canvas>`(`react-egui-elements`): `style` / `sense` / `on_paint` / `on_drag` / `on_hover`。`leaf_fill` で taffy がサイズを決める。egui-wgpu には依存しない。kittest 付き。
+- `examples/shader`: `lib.rs`(App)/ `gpu.rs`(`setup(cc)`、`ShaderResources`、`ShaderCallback: CallbackTrait`)/ `shader.wgsl` / `main.rs`。Slider(speed)、Checkbox(pause)、drag で uniform を動かす。native と trunk で動く。gallery に登録し、gallery の `setup` で pipeline を登録する。
+- escape-hatch example の painter 節を `<Canvas>` に置き換える(1 行で済むなら)。
+- README の表に shader を足す。ARCHITECTURE 6 章に `Canvas`。
+
+### 含まない
+
+- shader の生 egui 版(差が出ない)。
+- wgpu 以外の描画 API、egui_glow の callback。
+- `Canvas` の可変 `Sense` 以上のイベント(ホイール、キー)。要望が出てから。
+
+## 成果物
+
+- `crates/react-egui-elements/src/canvas.rs` + `tests/canvas.rs`。
+- `examples/shader/`。
+- gallery / README / ARCHITECTURE の更新。plan.md 7 章に実装で判明した差分。
+
+## 終了条件
+
+- kittest: `Canvas` の `rect` が `w h` / `grow` に従う。`on_drag` / `on_hover` が発火する。shader の Slider が `speed` を変え、pause で `request_repaint` が止まる。
+- `cargo run -p shader` でアニメーションし、Slider で速度が変わる(目視)。`trunk serve` でブラウザでも同じ(目視、WebGPU 非対応ブラウザは WebGL fallback)。
+- gallery に shader が載り、他の example と同居して pipeline 登録が衝突しない。
+- CI(fmt / clippy / test / wasm check / trunk ループ)が緑。
+
+## 決めごと(着手時点での前提)
+
+- `Options.setup` で pipeline を作り、hook / context に wgpu の型を出さない(`use_context` で `RenderState` を配る案は採らない)。
+- `Canvas` は egui-wgpu を知らない。callback を `painter().add` するのは利用側。
+- 閉包 prop は `impl for<'a> FnOnce(&'a mut egui::Ui, egui::Rect)` と higher-ranked bound を明示する。`#[component]` は prop の省略された lifetime を props 構造体のものに書き換えるため、省略形はコンパイルできない(`VirtualList` で確認済み)。
+- `#[prop(default = ..)]` に式(`egui::Sense::hover()`)が通らなければ `Option<egui::Sense>` + `unwrap_or`。
+- snapshot(C-3)は kittest の `WgpuTestRenderer` に `callback_resources` を差し込めるかで決める。無理なら落として目視のみ。

--- a/docs/tasks/examples/plan.md
+++ b/docs/tasks/examples/plan.md
@@ -153,6 +153,8 @@ examples 節を表にする。
 
 ## 3. PR C: canvas(wgpu)
 
+**PR C は [docs/tasks/canvas/](../canvas/task.md) に切り出した。** 以下は切り出し時点の記録として残す。
+
 コンポーネントの中で wgpu の shader アニメーションを描く。core は無変更で済む。ランナー、elements、example の 3 段。
 
 ### 3.1 `react-egui-app` の `wgpu` feature

--- a/docs/tasks/examples/plan.md
+++ b/docs/tasks/examples/plan.md
@@ -547,3 +547,18 @@ pub fn VirtualList(
 - 途中でディスクが一杯になり(`ld: write() failed, errno=28`)、`target/debug/incremental`(6.9GB)を消して続けた。このセッションで target が 27GB まで育っている。
 
 **gallery の並び替え。** `showcase` を先頭にした(訪問者が最初に見るべきもの)。以下 counter / todo / form / theme / clock / custom-hook / escape-hatch / list-10k / layout / fetch。`Running` の `match` の既定は `<ShowcaseApp/>` に変え、`"counter"` の腕を明示した。gallery のテストが「最初は counter」を前提にしていたので直した(トグルのテストは、showcase に生 egui 版が無いので counter を選んでから確かめる)。README の表も同じ順にし、導入の一文に「まず showcase を見て、他は 1 つずつの話」と書いた。
+
+## 9. PR C の記録
+
+### 手順 6: `Options.setup`(と `wgpu` feature を置かない判断)
+
+**3.1 の前提が間違っていた。「eframe は default(glow)のまま」は eframe 0.36 では成り立たない。** eframe 0.36.1 の `default` feature は `["accesskit", "default_fonts", "links", "wayland", "web_screen_reader", "wgpu", "winit/default", "x11"]` で、**`glow` は入っていない**。`Renderer::Glow` は `glow` feature が無いと存在すらせず、`Renderer::default()` は `Wgpu` を返す。つまり **このリポジトリは最初から wgpu で描いていた**。0.35 までとは逆で、今は glow の方が opt-in である。
+
+そのため **`wgpu` feature は置かない**。一度は `wgpu = ["eframe/wgpu"]` を足したが、今日の eframe では何も変えない feature であり、API の雑音にしかならない。5 章の「wgpu を唯一の backend にするか」は、eframe 側が先に決めてくれた形になる。glow で動かしたい人は `eframe/glow` を明示する話で、それはこの crate の仕事ではない。判断の根拠は `crates/react-egui-app/Cargo.toml` のコメントと ARCHITECTURE 8 章に残した。
+
+**WebGL fallback も何もしなくても入っている。** `eframe/wgpu` → `egui-wgpu/default` → `wgpu/webgl`。3.1 の「wasm は `wgpu` の `webgl` feature を on にする」は不要だった。`[workspace.dependencies]` には `wgpu = "30.0"`(eframe 0.36.1 が使う版)を pin だけしてある。shader example が pipeline を組むときに同じ wgpu へリンクするため。
+
+**`Options.setup`** は 3.2 のとおり足した。型は `Option<Setup>`、`pub type Setup = Box<dyn FnOnce(&eframe::CreationContext<'_>)>`(clippy の `type_complexity` が生の型を蹴るので別名にした。API としてもこちらが読みやすい)。`ReactApp::new` の先頭で `take()` して呼ぶ。1 フレーム目に paint callback が追加されうるので、store を作るより前に走らせる。`ReactApp::new` の `options` 引数を `&Options` から `&mut Options` にし、native / wasm どちらの起動閉包も `options` を move で持って `take` する(閉包はどちらも 1 回しか呼ばれない)。
+
+- テストは `crates/react-egui-app/src/lib.rs` の `#[cfg(test)] mod tests` に 1 つ、`setup` の既定が `None` であること。kittest は eframe を動かせないので、実際に wgpu で描かれることの確認は目視(`RUST_LOG=eframe=info`)に委ねる。
+- ARCHITECTURE 7 章(`Options` の一覧と `setup`)と 8 章(バックエンドと WebGL fallback)を更新。

--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -39,6 +39,7 @@ fetch = { path = "../fetch" }
 form = { path = "../form" }
 layout = { path = "../layout" }
 list-10k = { path = "../list-10k" }
+shader = { path = "../shader" }
 showcase = { path = "../showcase" }
 theme = { path = "../theme" }
 todo = { path = "../todo" }

--- a/examples/gallery/src/lib.rs
+++ b/examples/gallery/src/lib.rs
@@ -19,6 +19,7 @@ use fetch::App as FetchApp;
 use form::App as FormApp;
 use layout::App as LayoutApp;
 use list_10k::App as ListApp;
+use shader::App as ShaderApp;
 use showcase::App as ShowcaseApp;
 use theme::App as ThemeApp;
 use todo::App as TodoApp;
@@ -38,6 +39,7 @@ pub const EXAMPLES: &[Meta] = &[
     clock::META,
     custom_hook::META,
     escape_hatch::META,
+    shader::META,
     list_10k::META,
     layout::META,
     fetch::META,
@@ -221,6 +223,7 @@ fn Running(cx: &mut Cx, name: &'static str, plain: bool) {
                 "clock" => { <ClockApp/> }
                 "custom-hook" => { <CustomHookApp/> }
                 "escape-hatch" => { <EscapeHatchApp/> }
+                "shader" => { <ShaderApp/> }
                 // A thousand, not the ten thousand the binary opens with: at
                 // 10k a frame takes ~85ms, and the gallery around it would
                 // crawl too. The slider still reaches 10k for anyone curious.

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -11,6 +11,10 @@ fn main() -> eframe::Result {
     run(
         Options {
             title: String::from("react-egui: gallery"),
+            // The shader example's pipeline, built once for the whole gallery.
+            // It lands in `callback_resources` under its own type, so it costs
+            // the other examples nothing and cannot clash with them.
+            setup: Some(Box::new(shader::gpu::setup)),
             // Three columns need more than eframe's default 640: the list and
             // the code take 200 and 40%, and the example gets what is left.
             #[cfg(not(target_arch = "wasm32"))]

--- a/examples/gallery/tests/snapshots.rs
+++ b/examples/gallery/tests/snapshots.rs
@@ -202,6 +202,12 @@ single!(theme, egui::vec2(420.0, 420.0));
 // The module is the crate's lib name, so the image is `custom_hook.png`.
 single!(custom_hook, egui::vec2(420.0, 620.0));
 single!(escape_hatch, egui::vec2(420.0, 620.0), two_samples);
+// `shader` has no picture here. Its canvas is a wgpu paint callback, and the
+// pipeline behind it is built by `Options::setup` from eframe's render state —
+// which `WgpuTestRenderer` does not hand out, so the callback would find no
+// `ShaderResources` and draw nothing. On top of that the app asks for a repaint
+// every frame, so the picture would never be the same twice. Checked by eye
+// instead; see plan.md section 3.
 
 /// The clock, written out rather than through [`single!`], because its picture
 /// has to be pinned to a time.

--- a/examples/shader/Cargo.toml
+++ b/examples/shader/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "shader"
+description = "react-egui example: a wgpu fragment shader in a <Canvas>"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lib]
+name = "shader"
+path = "src/lib.rs"
+
+[[bin]]
+name = "shader"
+path = "src/main.rs"
+
+[dependencies]
+eframe.workspace = true
+egui.workspace = true
+egui-wgpu.workspace = true
+wgpu.workspace = true
+bytemuck.workspace = true
+log.workspace = true
+react-egui.workspace = true
+react-egui-app.workspace = true
+react-egui-elements.workspace = true
+example-meta.workspace = true
+
+[dev-dependencies]
+egui_kittest.workspace = true

--- a/examples/shader/Trunk.toml
+++ b/examples/shader/Trunk.toml
@@ -1,0 +1,3 @@
+[build]
+target = "index.html"
+dist = "dist"

--- a/examples/shader/index.html
+++ b/examples/shader/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <title>react-egui: shader</title>
+    <link data-trunk rel="rust" href="Cargo.toml" data-bin="shader" data-wasm-opt="z" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #101010;
+      }
+      canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="react_egui_canvas"></canvas>
+  </body>
+</html>

--- a/examples/shader/src/gpu.rs
+++ b/examples/shader/src/gpu.rs
@@ -1,0 +1,183 @@
+//! The wgpu side: build the pipeline once, then draw three vertices a frame.
+
+use std::num::NonZeroU64;
+
+use egui_wgpu::CallbackTrait;
+
+/// What the shader reads, laid out the way WGSL expects it.
+///
+/// `vec2<f32>` is 8-byte aligned in a uniform block, so `resolution` lands at
+/// offset 8 and `mouse` at 16; the tail padding takes the block to a multiple
+/// of 16, which is what a uniform binding has to be.
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Uniform {
+    time: f32,
+    speed: f32,
+    resolution: [f32; 2],
+    mouse: [f32; 2],
+    _padding: [f32; 2],
+}
+
+/// The pipeline and its uniform buffer, parked in `callback_resources`.
+///
+/// One per app, built in [`setup`] and found again by type. Nothing else in
+/// the process has this type, so a gallery running several examples cannot
+/// collide with it.
+pub struct ShaderResources {
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+    buffer: wgpu::Buffer,
+}
+
+/// Build the pipeline and hand it to the renderer. Call once, from
+/// `Options::setup`.
+///
+/// `cc.wgpu_render_state` is `None` when eframe was built without wgpu (or
+/// started on glow), and there is nothing to build against; the app still runs,
+/// the canvas is simply empty.
+pub fn setup(cc: &eframe::CreationContext<'_>) {
+    let Some(render_state) = cc.wgpu_render_state.as_ref() else {
+        log::warn!("shader: no wgpu render state, the canvas will stay blank");
+        return;
+    };
+    let device = &render_state.device;
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("shader_example"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+    });
+
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("shader_example_uniform"),
+        size: size_of::<Uniform>() as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("shader_example_bind_group_layout"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: NonZeroU64::new(size_of::<Uniform>() as u64),
+            },
+            count: None,
+        }],
+    });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("shader_example_bind_group"),
+        layout: &layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: buffer.as_entire_binding(),
+        }],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("shader_example_pipeline_layout"),
+        bind_group_layouts: &[Some(&layout)],
+        // `var<immediate>` is wgpu 30's push constants; the shader uses none.
+        immediate_size: 0,
+    });
+
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("shader_example_pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            compilation_options: Default::default(),
+            // No vertex buffer: the triangle comes out of `vertex_index`.
+            buffers: &[],
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            compilation_options: Default::default(),
+            // The same format egui itself draws into, because this pipeline
+            // shares egui's render pass.
+            targets: &[Some(render_state.target_format.into())],
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    });
+
+    render_state
+        .renderer
+        .write()
+        .callback_resources
+        .insert(ShaderResources {
+            pipeline,
+            bind_group,
+            buffer,
+        });
+}
+
+/// One frame's worth of state, on its way to the uniform buffer.
+///
+/// The values are read from hooks in `App` and copied in here, so the whole
+/// path from a `Slider` to a pixel is: `use_state` -> this struct ->
+/// `queue.write_buffer` -> WGSL.
+pub struct ShaderCallback {
+    /// Seconds, already multiplied by `speed` and frozen while paused.
+    pub time: f32,
+    /// The slider's value, so the shader can colour by it too.
+    pub speed: f32,
+    /// The canvas size in physical pixels.
+    pub resolution: egui::Vec2,
+    /// Where dragging has pushed the pattern, in pixels.
+    pub mouse: egui::Vec2,
+}
+
+impl CallbackTrait for ShaderCallback {
+    fn prepare(
+        &self,
+        _device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        _screen_descriptor: &egui_wgpu::ScreenDescriptor,
+        _encoder: &mut wgpu::CommandEncoder,
+        resources: &mut egui_wgpu::CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        if let Some(res) = resources.get::<ShaderResources>() {
+            queue.write_buffer(
+                &res.buffer,
+                0,
+                bytemuck::bytes_of(&Uniform {
+                    time: self.time,
+                    speed: self.speed,
+                    resolution: [self.resolution.x, self.resolution.y],
+                    mouse: [self.mouse.x, self.mouse.y],
+                    _padding: [0.0; 2],
+                }),
+            );
+        }
+        // Nothing of our own to submit: the write above rides egui's queue.
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        _info: egui::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        resources: &egui_wgpu::CallbackResources,
+    ) {
+        // Missing only if `setup` never ran; draw nothing rather than panic
+        // inside egui's render pass.
+        let Some(res) = resources.get::<ShaderResources>() else {
+            return;
+        };
+        render_pass.set_pipeline(&res.pipeline);
+        render_pass.set_bind_group(0, &res.bind_group, &[]);
+        // Three vertices, one triangle, clipped to the callback's rect by the
+        // viewport and scissor egui-wgpu has already set.
+        render_pass.draw(0..3, 0..1);
+    }
+}

--- a/examples/shader/src/lib.rs
+++ b/examples/shader/src/lib.rs
@@ -1,0 +1,100 @@
+//! A wgpu fragment shader in a `<Canvas>`, driven by ordinary hooks.
+//!
+//! Three pieces meet here, and each stays on its own side of the fence.
+//!
+//! The pipeline is built once, at startup, by `Options::setup` (see
+//! `main.rs`). eframe hands that closure a `CreationContext` with a
+//! `wgpu_render_state` in it, and `gpu::setup` puts a `ShaderResources` into
+//! `renderer.write().callback_resources`. That is a `TypeMap`, so the entry is
+//! found again by its type and cannot clash with another example's — which is
+//! what lets the gallery run this one alongside the rest.
+//!
+//! The `<Canvas>` element knows nothing about any of it. It asks taffy for a
+//! rect and calls `paint` with it; what goes in there is the caller's business.
+//! Here it is one line: push an `egui_wgpu::Callback` onto the painter, and
+//! egui will run it inside its own render pass with the viewport and scissor
+//! already set to the rect.
+//!
+//! State is the point of the example. `speed` and `paused` are `use_state`
+//! like anywhere else, and the values are copied into the callback struct,
+//! written to a uniform buffer in `prepare`, and read by the WGSL. Moving the
+//! slider changes a number in a hook and the picture changes; nothing in
+//! between has to be told.
+//!
+//! Repainting is explicit, as always in egui: while the animation runs the app
+//! asks for the next frame every frame, and `pause` simply stops asking, which
+//! also freezes `time` at the value the last frame saw.
+
+use example_meta::Meta;
+use react_egui::prelude::*;
+use react_egui_elements::prelude::*;
+
+pub mod gpu;
+
+pub const META: Meta = Meta {
+    name: "shader",
+    summary: "A wgpu fragment shader in a <Canvas>, with a slider wired to its uniform.",
+    hooks: &["use_state"],
+    elements: &["View", "Canvas", "Slider", "Checkbox"],
+    source: include_str!("lib.rs"),
+    plain: None,
+};
+
+/// The shader canvas, a speed slider and a pause box.
+#[component]
+pub fn App(cx: &mut Cx) {
+    let mut speed = use_state(cx, || 1.0f32);
+    let mut paused = use_state(cx, || false);
+    let mut mouse = use_state(cx, || egui::Vec2::ZERO);
+
+    // egui's own clock, in seconds since the app started. It stops moving when
+    // no repaint is asked for, which is what makes `pause` work.
+    let time = cx.ui().input(|i| i.time) as f32;
+    // A shader animates, so it needs a frame a frame; asking here rather than
+    // in `paint` keeps the request out of the drawing code.
+    if !*paused {
+        cx.ctx().request_repaint();
+    }
+
+    // Read the states once. The handlers below take them `&mut`, and `paint`
+    // is a separate closure that would otherwise hold a borrow across them.
+    let speed_value = *speed;
+    let mouse_value = *mouse;
+    let points_to_pixels = cx.ctx().pixels_per_point();
+
+    rsx! {
+        <View direction="column" gap={8} p={12} grow={1.0}>
+            <Text size={22.0} strong>"shader"</Text>
+            <Text>"Drag the canvas to move the pattern."</Text>
+            // `h={0}` with `grow={1}` is the flexbox idiom for "take what is
+            // left and nothing more". A `<Canvas>` reports the whole window as
+            // the size it could fill, and this column's height is decided by
+            // its content, so `grow` on its own would size the column to the
+            // canvas *plus* the controls and push the row below off the
+            // bottom. Zero height and a share of the free space instead.
+            <Canvas
+                grow={1.0}
+                h={0.0}
+                sense={egui::Sense::drag()}
+                on_drag={|delta: egui::Vec2| *mouse += delta}
+                paint={move |ui: &mut egui::Ui, rect: egui::Rect| {
+                    // The shader works in pixels, and a rect is in points.
+                    let resolution = rect.size() * points_to_pixels;
+                    ui.painter().add(egui_wgpu::Callback::new_paint_callback(
+                        rect,
+                        gpu::ShaderCallback {
+                            time: time * speed_value,
+                            speed: speed_value,
+                            resolution,
+                            mouse: mouse_value * points_to_pixels,
+                        },
+                    ));
+                }}
+            />
+            <View direction="row" gap={12} align="center">
+                <Slider bind={speed.bind()} range={0.0..=4.0} label="speed"/>
+                <Checkbox bind={paused.bind()} label="pause"/>
+            </View>
+        </View>
+    }
+}

--- a/examples/shader/src/main.rs
+++ b/examples/shader/src/main.rs
@@ -1,0 +1,18 @@
+//! Runs the `shader` example on its own; the app itself is in `lib.rs`.
+
+use react_egui::prelude::*;
+use react_egui_app::{Options, run};
+use shader::{App, gpu};
+
+fn main() -> eframe::Result {
+    run(
+        Options {
+            title: String::from("react-egui: shader"),
+            // The one place the pipeline can be built: eframe has a window and
+            // a wgpu device here, and nothing has been drawn yet.
+            setup: Some(Box::new(gpu::setup)),
+            ..Default::default()
+        },
+        |_cx| rsx! { <App/> },
+    )
+}

--- a/examples/shader/src/shader.wgsl
+++ b/examples/shader/src/shader.wgsl
@@ -1,0 +1,62 @@
+// A fullscreen triangle and a plasma, driven by the app's state.
+
+struct Uniform {
+    time: f32,
+    speed: f32,
+    resolution: vec2<f32>,
+    mouse: vec2<f32>,
+};
+
+@group(0) @binding(0) var<uniform> u: Uniform;
+
+struct VertexOut {
+    @builtin(position) position: vec4<f32>,
+    // The clip position carried through as a varying. `@builtin(position)` in
+    // the fragment stage is in whole-framebuffer pixels, so it would need the
+    // rect's offset to be useful; interpolating the clip coordinate gives
+    // -1..1 across the canvas rect and nothing else has to be passed in.
+    @location(0) uv: vec2<f32>,
+};
+
+// One triangle big enough to cover the whole clip space, so there is no vertex
+// buffer to bind. egui-wgpu has already set the viewport and the scissor to
+// the canvas rect, so the triangle lands exactly on it.
+@vertex
+fn vs_main(@builtin(vertex_index) index: u32) -> VertexOut {
+    let x = f32(i32(index) / 2) * 4.0 - 1.0;
+    let y = f32(i32(index) & 1) * 4.0 - 1.0;
+    var out: VertexOut;
+    out.position = vec4<f32>(x, y, 0.0, 1.0);
+    out.uv = vec2<f32>(x, y);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    // Square the coordinates up, so the pattern does not stretch with the
+    // window.
+    let size = max(u.resolution, vec2<f32>(1.0, 1.0));
+    var uv = vec2<f32>(in.uv.x * size.x / size.y, in.uv.y);
+    // Dragging pushes the pattern around: the drag total arrives in pixels.
+    uv = uv + vec2<f32>(u.mouse.x, -u.mouse.y) / size.y * 2.0;
+
+    let t = u.time;
+    let r = length(uv);
+    // Four waves out of step with each other, so the colours drift apart
+    // instead of moving as one grey pulse.
+    var v = sin(uv.x * 4.0 + t);
+    v = v + sin(uv.y * 4.0 - t * 1.3);
+    v = v + sin((uv.x + uv.y) * 3.0 + t * 0.7);
+    v = v + sin(r * 8.0 - t * 2.0);
+    v = v * 0.25;
+
+    // The slider shows up in the picture as well as in the pace: a faster
+    // setting is a warmer one, so a paused canvas still reacts to it.
+    let warmth = clamp(u.speed * 0.25, 0.0, 1.0);
+    let color = vec3<f32>(
+        0.5 + 0.5 * sin(v * 3.14159 + warmth * 2.0),
+        0.5 + 0.5 * sin(v * 3.14159 + 2.094),
+        0.5 + 0.5 * sin(v * 3.14159 + 4.188 - warmth),
+    );
+    return vec4<f32>(color, 1.0);
+}

--- a/examples/shader/tests/app.rs
+++ b/examples/shader/tests/app.rs
@@ -1,0 +1,110 @@
+//! Plan test C-2: the slider moves `speed`, and `pause` stops the repaints.
+//!
+//! Headless, like every other example test. The `<Canvas>` pushes an
+//! `egui_wgpu::Callback` onto the painter, but the harness's default renderer
+//! never executes paint callbacks — it only collects the shapes — so no wgpu
+//! device is needed here and `gpu::setup` is never called. What is tested is
+//! the part that is this crate's own: state reaching the callback, and the
+//! repaint request that makes the animation run.
+
+use egui_kittest::Harness;
+use egui_kittest::kittest::{NodeT as _, Queryable as _};
+use react_egui::prelude::*;
+use react_egui_app::{root_id, root_style};
+use shader::App;
+
+fn harness<'a>() -> Harness<'a, Store> {
+    Harness::builder()
+        .with_size(egui::vec2(420.0, 520.0))
+        .build_ui_state(
+            |ui, store: &mut Store| {
+                store.begin_pass(ui.ctx());
+                {
+                    let store: &Store = store;
+                    let mut cx = Cx::new(store, ui, root_id());
+                    let view = rsx! { <App/> };
+                    cx.root_container(root_id(), root_style(), |cx| view.show(cx));
+                }
+                store.end_pass();
+            },
+            Store::new(),
+        )
+}
+
+/// The slider's own reading. The canvas has no text to check, so the value is
+/// read from the accessibility tree rather than from the picture.
+fn speed(harness: &Harness<'_, Store>) -> f64 {
+    harness
+        .get_by_role(egui::accesskit::Role::Slider)
+        .accesskit_node()
+        .numeric_value()
+        .expect("the speed slider should report its value")
+}
+
+#[test]
+fn the_slider_moves_the_speed() {
+    let mut harness = harness();
+    harness.step();
+    assert_eq!(speed(&harness), 1.0);
+
+    // Dragging is fiddly headless; focusing and nudging is the stable way.
+    harness.get_by_role(egui::accesskit::Role::Slider).focus();
+    harness.step();
+    harness.key_press(egui::Key::ArrowRight);
+    // One pass to apply the write, one to draw with it.
+    harness.step();
+    harness.step();
+
+    assert!(
+        speed(&harness) > 1.0,
+        "the slider did not change the speed: {}",
+        speed(&harness),
+    );
+}
+
+/// The animation is nothing but a repaint request, so pausing is the absence
+/// of one.
+///
+/// `step`, not `run`: a running animation asks for the next frame every frame,
+/// and `run` would never decide it had settled.
+#[test]
+fn pausing_stops_the_repaint_requests() {
+    let mut harness = harness();
+    harness.step();
+    assert!(
+        harness.ctx.has_requested_repaint(),
+        "the animation should ask for the next frame",
+    );
+
+    harness.get_by_label("pause").click();
+    // One pass to apply the write, then let egui's own checkbox animation
+    // finish; `run_ok` settles it and does not panic if it cannot.
+    harness.step();
+    harness.run_ok();
+    harness.step();
+
+    assert!(
+        !harness.ctx.has_requested_repaint(),
+        "a paused canvas kept asking for frames",
+    );
+}
+
+/// The canvas takes the space that is left, not the whole window.
+///
+/// A `<Canvas>` reports the window as the size it *could* fill, so `grow` on
+/// its own makes the column taller than the window and pushes the controls out
+/// of sight. `h={0}` next to `grow` is what keeps them on screen.
+#[test]
+fn the_controls_stay_below_the_canvas() {
+    const HEIGHT: f32 = 520.0;
+
+    let mut harness = harness();
+    harness.step();
+
+    let slider = harness.get_by_role(egui::accesskit::Role::Slider).rect();
+    let pause = harness.get_by_label("pause").rect();
+    assert!(
+        slider.bottom() <= HEIGHT && pause.bottom() <= HEIGHT,
+        "the canvas pushed the controls off the bottom: {slider:?} {pause:?}",
+    );
+}

--- a/plan-overview.md
+++ b/plan-overview.md
@@ -22,7 +22,8 @@
 | PR2 | 2, 3, 4, 5 | `docs/tasks/core/` |
 | PR3 | 6 | `docs/tasks/async/` |
 | PR4 | 7 | `docs/tasks/mobile/` |
-| PR5, PR6, PR7 | 6.5 | `docs/tasks/examples/` |
+| PR5, PR6 | 6.5 | `docs/tasks/examples/` |
+| PR7 | 6.5(canvas) | `docs/tasks/canvas/` |
 
 フェーズ 8(公開準備)は PR4 の後に別途計画する。
 


### PR DESCRIPTION
## Summary

Canvas task (`docs/tasks/canvas/`, the old PR C of the examples plan): a `<Canvas>` leaf element and a wgpu shader example, plus the runner hook `Options.setup` they need. Core crates (`react-egui`, `react-egui-macros`) are untouched.

## Changes

- Added `Options.setup` (`react-egui-app`): one-time init with `CreationContext`, where wgpu pipelines go into `callback_resources`
  - No `wgpu` feature: eframe 0.36 already defaults to wgpu, WebGL fallback comes via `egui-wgpu/default`
- Added `<Canvas>` (`react-egui-elements`): `sense` / `paint`, `on_drag` / `on_hover`; taffy sizes it via `leaf_fill`, no egui-wgpu dependency
  - Prop is `paint`, not `on_paint`: `rsx!` treats every `on_` attribute as an event
  - kittest: rect follows `w h` / `grow`, drag and hover fire
- Added `examples/shader`: fullscreen-triangle fragment shader, `use_state` → uniform (speed slider, pause, drag)
  - `gpu::setup` builds the pipeline; `ShaderCallback: CallbackTrait`
  - Registered in gallery (`Options.setup` calls `shader::gpu::setup`), README row
  - `<Canvas grow h={0}>` needed: a `leaf_fill` leaf reports the whole window as content size, `grow` alone pushed the controls off the bottom
- Added `docs/tasks/canvas/` task and plan (with what changed during implementation); ARCHITECTURE 6 / 7 / 8
