### PR TITLE
chore: replace plasma shader with gravitationally lensed black hole

### DIFF
--- a/examples/shader/src/gpu.rs
+++ b/examples/shader/src/gpu.rs
@@ -13,10 +13,15 @@ use egui_wgpu::CallbackTrait;
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct Uniform {
     time: f32,
-    speed: f32,
+    mass: f32,
     resolution: [f32; 2],
     mouse: [f32; 2],
-    _padding: [f32; 2],
+    /// 1.0 when the target format encodes sRGB on write, 0.0 when it does not.
+    /// The shader works in linear light and has to do the encoding itself in
+    /// the second case. This one used to be padding, so the block is the same
+    /// size it always was.
+    srgb_target: f32,
+    _padding: f32,
 }
 
 /// The pipeline and its uniform buffer, parked in `callback_resources`.
@@ -28,6 +33,10 @@ pub struct ShaderResources {
     pipeline: wgpu::RenderPipeline,
     bind_group: wgpu::BindGroup,
     buffer: wgpu::Buffer,
+    /// Decided once, when the render state is known, and passed along to every
+    /// frame's uniform. The app has no business knowing about it, so it lives
+    /// here rather than on [`ShaderCallback`].
+    srgb_target: bool,
 }
 
 /// Build the pipeline and hand it to the renderer. Call once, from
@@ -118,6 +127,7 @@ pub fn setup(cc: &eframe::CreationContext<'_>) {
             pipeline,
             bind_group,
             buffer,
+            srgb_target: render_state.target_format.is_srgb(),
         });
 }
 
@@ -129,11 +139,11 @@ pub fn setup(cc: &eframe::CreationContext<'_>) {
 pub struct ShaderCallback {
     /// Seconds, already multiplied by `speed` and frozen while paused.
     pub time: f32,
-    /// The slider's value, so the shader can colour by it too.
-    pub speed: f32,
+    /// The Schwarzschild radius in scene units, straight off the mass slider.
+    pub mass: f32,
     /// The canvas size in physical pixels.
     pub resolution: egui::Vec2,
-    /// Where dragging has pushed the pattern, in pixels.
+    /// Where dragging has turned the camera, in pixels.
     pub mouse: egui::Vec2,
 }
 
@@ -152,10 +162,11 @@ impl CallbackTrait for ShaderCallback {
                 0,
                 bytemuck::bytes_of(&Uniform {
                     time: self.time,
-                    speed: self.speed,
+                    mass: self.mass,
                     resolution: [self.resolution.x, self.resolution.y],
                     mouse: [self.mouse.x, self.mouse.y],
-                    _padding: [0.0; 2],
+                    srgb_target: if res.srgb_target { 1.0 } else { 0.0 },
+                    _padding: 0.0,
                 }),
             );
         }

--- a/examples/shader/src/gpu.rs
+++ b/examples/shader/src/gpu.rs
@@ -6,22 +6,23 @@ use egui_wgpu::CallbackTrait;
 
 /// What the shader reads, laid out the way WGSL expects it.
 ///
-/// `vec2<f32>` is 8-byte aligned in a uniform block, so `resolution` lands at
-/// offset 8 and `mouse` at 16; the tail padding takes the block to a multiple
-/// of 16, which is what a uniform binding has to be.
+/// Four scalars first, so that the `vec2<f32>`s — 8-byte aligned in a uniform
+/// block — land at offsets 16 and 24 with no gap; the tail padding takes the
+/// block to a multiple of 16, which is what a uniform binding has to be.
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct Uniform {
     time: f32,
     mass: f32,
+    bloom: f32,
+    tilt: f32,
     resolution: [f32; 2],
     mouse: [f32; 2],
     /// 1.0 when the target format encodes sRGB on write, 0.0 when it does not.
     /// The shader works in linear light and has to do the encoding itself in
-    /// the second case. This one used to be padding, so the block is the same
-    /// size it always was.
+    /// the second case.
     srgb_target: f32,
-    _padding: f32,
+    _padding: [f32; 3],
 }
 
 /// The pipeline and its uniform buffer, parked in `callback_resources`.
@@ -141,6 +142,10 @@ pub struct ShaderCallback {
     pub time: f32,
     /// The Schwarzschild radius in scene units, straight off the mass slider.
     pub mass: f32,
+    /// Strength and spread of the disk's glow; 1.0 is the default look.
+    pub bloom: f32,
+    /// The camera's roll about the view axis, in radians.
+    pub tilt: f32,
     /// The canvas size in physical pixels.
     pub resolution: egui::Vec2,
     /// Where dragging has turned the camera, in pixels.
@@ -163,10 +168,12 @@ impl CallbackTrait for ShaderCallback {
                 bytemuck::bytes_of(&Uniform {
                     time: self.time,
                     mass: self.mass,
+                    bloom: self.bloom,
+                    tilt: self.tilt,
                     resolution: [self.resolution.x, self.resolution.y],
                     mouse: [self.mouse.x, self.mouse.y],
                     srgb_target: if res.srgb_target { 1.0 } else { 0.0 },
-                    _padding: 0.0,
+                    _padding: [0.0; 3],
                 }),
             );
         }

--- a/examples/shader/src/lib.rs
+++ b/examples/shader/src/lib.rs
@@ -21,9 +21,10 @@
 //! egui will run it inside its own render pass with the viewport and scissor
 //! already set to the rect.
 //!
-//! State is the point of the example. `speed`, `mass` and `paused` are
-//! `use_state` like anywhere else, and the values are copied into the callback
-//! struct, written to a uniform buffer in `prepare`, and read by the WGSL.
+//! State is the point of the example. `speed`, `mass`, `bloom`, `tilt` and
+//! `paused` are `use_state` like anywhere else, and the values are copied into
+//! the callback struct, written to a uniform buffer in `prepare`, and read by
+//! the WGSL.
 //! Moving a slider changes a number in a hook and the picture changes; nothing
 //! in between has to be told. `mass` is the one to try first: it is the
 //! Schwarzschild radius the shader traces photons around, so it sets the size
@@ -49,11 +50,15 @@ pub const META: Meta = Meta {
     plain: None,
 };
 
-/// The shader canvas, two sliders and a pause box.
+/// The shader canvas, four sliders and a pause box.
 #[component]
 pub fn App(cx: &mut Cx) {
     let mut speed = use_state(cx, || 1.0f32);
-    let mut mass = use_state(cx, || 0.7f32);
+    let mut mass = use_state(cx, || 0.85f32);
+    let mut bloom = use_state(cx, || 1.0f32);
+    // Degrees, because that is what a slider labelled "tilt" should show; the
+    // shader gets radians.
+    let mut tilt = use_state(cx, || 22.0f32);
     let mut paused = use_state(cx, || false);
     let mut mouse = use_state(cx, || egui::Vec2::ZERO);
 
@@ -70,6 +75,8 @@ pub fn App(cx: &mut Cx) {
     // is a separate closure that would otherwise hold a borrow across them.
     let speed_value = *speed;
     let mass_value = *mass;
+    let bloom_value = *bloom;
+    let tilt_value = tilt.to_radians();
     let mouse_value = *mouse;
     let points_to_pixels = cx.ctx().pixels_per_point();
 
@@ -96,6 +103,8 @@ pub fn App(cx: &mut Cx) {
                         gpu::ShaderCallback {
                             time: time * speed_value,
                             mass: mass_value,
+                            bloom: bloom_value,
+                            tilt: tilt_value,
                             resolution,
                             mouse: mouse_value * points_to_pixels,
                         },
@@ -104,6 +113,8 @@ pub fn App(cx: &mut Cx) {
             />
             <View direction="row" gap={12} align="center" wrap>
                 <Slider bind={mass.bind()} range={0.1..=2.0} label="mass"/>
+                <Slider bind={bloom.bind()} range={0.0..=4.0} label="bloom"/>
+                <Slider bind={tilt.bind()} range={-60.0..=60.0} label="tilt"/>
                 <Slider bind={speed.bind()} range={0.0..=4.0} label="speed"/>
                 <Checkbox bind={paused.bind()} label="pause"/>
             </View>

--- a/examples/shader/src/lib.rs
+++ b/examples/shader/src/lib.rs
@@ -1,5 +1,11 @@
 //! A wgpu fragment shader in a `<Canvas>`, driven by ordinary hooks.
 //!
+//! What it draws is a black hole: one fullscreen triangle, and for every pixel
+//! of it a photon traced backwards from the camera through curved space until
+//! it meets the accretion disk, the sky, or the horizon. `shader.wgsl` is where
+//! that lives and it explains itself; the interesting part here is that none of
+//! the code below knows any of it.
+//!
 //! Three pieces meet here, and each stays on its own side of the fence.
 //!
 //! The pipeline is built once, at startup, by `Options::setup` (see
@@ -15,11 +21,14 @@
 //! egui will run it inside its own render pass with the viewport and scissor
 //! already set to the rect.
 //!
-//! State is the point of the example. `speed` and `paused` are `use_state`
-//! like anywhere else, and the values are copied into the callback struct,
-//! written to a uniform buffer in `prepare`, and read by the WGSL. Moving the
-//! slider changes a number in a hook and the picture changes; nothing in
-//! between has to be told.
+//! State is the point of the example. `speed`, `mass` and `paused` are
+//! `use_state` like anywhere else, and the values are copied into the callback
+//! struct, written to a uniform buffer in `prepare`, and read by the WGSL.
+//! Moving a slider changes a number in a hook and the picture changes; nothing
+//! in between has to be told. `mass` is the one to try first: it is the
+//! Schwarzschild radius the shader traces photons around, so it sets the size
+//! of the shadow, how far the sky behind bends around it, and how much of the
+//! disk the hole has eaten.
 //!
 //! Repainting is explicit, as always in egui: while the animation runs the app
 //! asks for the next frame every frame, and `pause` simply stops asking, which
@@ -33,17 +42,18 @@ pub mod gpu;
 
 pub const META: Meta = Meta {
     name: "shader",
-    summary: "A wgpu fragment shader in a <Canvas>, with a slider wired to its uniform.",
+    summary: "A ray-traced black hole in a <Canvas>, with sliders wired to its uniform.",
     hooks: &["use_state"],
     elements: &["View", "Canvas", "Slider", "Checkbox"],
     source: include_str!("lib.rs"),
     plain: None,
 };
 
-/// The shader canvas, a speed slider and a pause box.
+/// The shader canvas, two sliders and a pause box.
 #[component]
 pub fn App(cx: &mut Cx) {
     let mut speed = use_state(cx, || 1.0f32);
+    let mut mass = use_state(cx, || 0.7f32);
     let mut paused = use_state(cx, || false);
     let mut mouse = use_state(cx, || egui::Vec2::ZERO);
 
@@ -59,13 +69,14 @@ pub fn App(cx: &mut Cx) {
     // Read the states once. The handlers below take them `&mut`, and `paint`
     // is a separate closure that would otherwise hold a borrow across them.
     let speed_value = *speed;
+    let mass_value = *mass;
     let mouse_value = *mouse;
     let points_to_pixels = cx.ctx().pixels_per_point();
 
     rsx! {
         <View direction="column" gap={8} p={12} grow={1.0}>
             <Text size={22.0} strong>"shader"</Text>
-            <Text>"Drag the canvas to move the pattern."</Text>
+            <Text>"Drag the canvas to orbit the camera."</Text>
             // `h={0}` with `grow={1}` is the flexbox idiom for "take what is
             // left and nothing more". A `<Canvas>` reports the whole window as
             // the size it could fill, and this column's height is decided by
@@ -84,14 +95,15 @@ pub fn App(cx: &mut Cx) {
                         rect,
                         gpu::ShaderCallback {
                             time: time * speed_value,
-                            speed: speed_value,
+                            mass: mass_value,
                             resolution,
                             mouse: mouse_value * points_to_pixels,
                         },
                     ));
                 }}
             />
-            <View direction="row" gap={12} align="center">
+            <View direction="row" gap={12} align="center" wrap>
+                <Slider bind={mass.bind()} range={0.1..=2.0} label="mass"/>
                 <Slider bind={speed.bind()} range={0.0..=4.0} label="speed"/>
                 <Checkbox bind={paused.bind()} label="pause"/>
             </View>

--- a/examples/shader/src/lib.rs
+++ b/examples/shader/src/lib.rs
@@ -54,8 +54,8 @@ pub const META: Meta = Meta {
 #[component]
 pub fn App(cx: &mut Cx) {
     let mut speed = use_state(cx, || 1.0f32);
-    let mut mass = use_state(cx, || 0.85f32);
-    let mut bloom = use_state(cx, || 1.0f32);
+    let mut mass = use_state(cx, || 1.0f32);
+    let mut bloom = use_state(cx, || 1.5f32);
     // Degrees, because that is what a slider labelled "tilt" should show; the
     // shader gets radians.
     let mut tilt = use_state(cx, || 22.0f32);

--- a/examples/shader/src/shader.wgsl
+++ b/examples/shader/src/shader.wgsl
@@ -2,20 +2,28 @@
 //
 // One fullscreen triangle, and for every pixel of it a photon traced backwards
 // from the camera through curved space. What the photon runs into on the way —
-// the accretion disk, the sky, or the horizon — is the colour of the pixel.
+// the accretion disk, the sky, or the horizon — is the colour of the pixel,
+// plus the glow of the disk it gathered along its path, which is how the
+// picture gets a bloom without a second pass.
 
 struct Uniform {
     time: f32,
     // The Schwarzschild radius in scene units. The slider writes it, and it
     // sets both the size of the shadow and how hard the light bends.
     mass: f32,
+    // How strong and how wide the disk's glow is; 1.0 is the default look.
+    bloom: f32,
+    // The camera's roll about the view axis, in radians.
+    tilt: f32,
     resolution: vec2<f32>,
     mouse: vec2<f32>,
     // 1.0 when egui is drawing into an sRGB surface format, 0.0 when it is
     // not. `gpu::setup` reads it off the render state; see the end of
     // `fs_main` for what it is for.
     srgb_target: f32,
-    _pad: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
 };
 
 @group(0) @binding(0) var<uniform> u: Uniform;
@@ -26,7 +34,15 @@ struct Uniform {
 const STEPS: i32 = 190;
 // The disk's outer edge, in scene units. Its inner edge follows the mass.
 const DISK_OUTER: f32 = 9.0;
-const CAM_DISTANCE: f32 = 17.0;
+
+// The framing, before any drag: close in, a few degrees above the disk, the
+// camera rolled so the disk runs up and to the right, and the hole off to the
+// right of centre so the near side of the disk can sweep in from the left.
+const CAM_DISTANCE: f32 = 10.5;
+const PITCH: f32 = 0.08;
+const HOLE_OFFSET: f32 = 0.6;
+// Larger is a narrower field of view.
+const FOCAL: f32 = 1.5;
 
 struct VertexOut {
     @builtin(position) position: vec4<f32>,
@@ -98,7 +114,7 @@ fn fbm2(p0: vec2<f32>) -> f32 {
 fn sky(dir: vec3<f32>) -> vec3<f32> {
     var col = vec3<f32>(0.0);
     var scale = 130.0;
-    var weight = 2.2;
+    var weight = 1.4;
     for (var i = 0; i < 2; i++) {
         let s = dir * scale;
         let cell = floor(s);
@@ -120,7 +136,7 @@ fn sky(dir: vec3<f32>) -> vec3<f32> {
     // near-black rather than a flat wash over the whole sky.
     let dust = fbm2(dir.xz * 2.2 + 3.0) * fbm2(dir.yx * 1.9 + 8.0);
     let cloud = smoothstep(0.22, 0.55, dust);
-    return col + vec3<f32>(0.004, 0.006, 0.018) + vec3<f32>(0.075, 0.045, 0.13) * cloud;
+    return col + vec3<f32>(0.008, 0.006, 0.006) + vec3<f32>(0.05, 0.03, 0.025) * cloud;
 }
 
 /// One layer of the disk's gas, wound up by `age` seconds of Keplerian shear.
@@ -129,7 +145,7 @@ fn sky(dir: vec3<f32>) -> vec3<f32> {
 /// by an angle that depends on its own radius is what turns plain noise into
 /// spiral arms, and it costs one sin and one cos.
 fn gas(p: vec3<f32>, radius: f32, age: f32) -> f32 {
-    let a = -age * 1.6 / pow(radius, 1.5);
+    let a = -age * 2.0 / pow(radius, 1.5);
     let c = cos(a);
     let s = sin(a);
     let q = vec2<f32>(p.x * c - p.z * s, p.x * s + p.z * c);
@@ -138,6 +154,40 @@ fn gas(p: vec3<f32>, radius: f32, age: f32) -> f32 {
 
 /// How long a layer of gas is wound before it is started over, in seconds.
 const CHURN: f32 = 7.0;
+
+/// Signed distance from `p` to the disk: a flat annulus in the y = 0 plane
+/// between `inner` and `DISK_OUTER`. Inside the annulus, the distance is the
+/// height above the plane; beyond an edge, the distance to that edge.
+fn disk_sdf(p: vec3<f32>, inner: f32) -> f32 {
+    let radius = length(p.xz);
+    let outside = max(max(inner - radius, radius - DISK_OUTER), 0.0);
+    return length(vec2<f32>(outside, p.y));
+}
+
+/// The disk's glow at `p`, for one step of length `dt`.
+///
+/// Bloom is normally a second pass over the finished picture, and this
+/// example wants to stay one pass. So instead the glow is accumulated along
+/// the ray, as a light that falls off with the square of the distance to the
+/// disk's surface: integrated over a ray that passes the disk at distance b,
+/// that comes to pi / b, which is the halo a real bloom would give. It has one
+/// thing a post-process cannot: the ray is bent, so the glow is lensed with the
+/// rest of the picture and the halo goes round the shadow with it.
+fn glow(p: vec3<f32>, dt: f32, inner: f32) -> vec3<f32> {
+    // The bloom slider widens the falloff as well as brightening it: a
+    // distance divided by `spread` reaches the same brightness `spread` times
+    // further out, and the integral along the ray grows with its square.
+    let spread = 0.7 + 0.6 * u.bloom;
+    let d = disk_sdf(p, inner) / spread;
+    // Colour it by the temperature of the nearest gas, so the glow is white
+    // near the hole and orange out at the rim, and let it fade with the rim.
+    let f = clamp((length(p.xz) - inner) / (DISK_OUTER - inner), 0.0, 1.0);
+    let heat = pow(1.0 - f, 2.6);
+    let col = mix(vec3<f32>(1.0, 0.56, 0.32), vec3<f32>(1.0, 0.95, 0.88), heat);
+    let rim = smoothstep(1.0, 0.72, f);
+    // The small constant caps the brightness at the surface itself.
+    return col * (0.25 + 2.0 * heat) * rim * dt / (d * d + 0.06);
+}
 
 /// The accretion disk, sampled where a ray crossed the y = 0 plane.
 ///
@@ -167,7 +217,7 @@ fn disk(p: vec3<f32>, ray_dir: vec3<f32>, t: f32, rs: f32, inner: f32) -> vec3<f
     // Soft at both edges, so the disk does not end on a hard circle.
     let edge = smoothstep(0.0, 0.09, f) * smoothstep(1.0, 0.72, f);
     let heat = pow(1.0 - f, 2.6);
-    var col = mix(vec3<f32>(1.0, 0.30, 0.05), vec3<f32>(1.0, 0.95, 0.88), heat);
+    var col = mix(vec3<f32>(1.0, 0.52, 0.28), vec3<f32>(1.0, 0.96, 0.90), heat);
 
     // Relativistic beaming. The gas orbits at a good fraction of c, and the
     // half of the disk turning towards the camera comes out brighter and bluer
@@ -201,17 +251,20 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     // starts just above the disk plane, which is the angle that shows both the
     // far side lensed over the top and the near side under the shadow.
     let yaw = u.mouse.x / size.y * 2.4;
-    let pitch = clamp(0.15 + u.mouse.y / size.y * 2.4, -1.45, 1.45);
+    let pitch = clamp(PITCH + u.mouse.y / size.y * 2.4, -1.45, 1.45);
     let cam = vec3<f32>(sin(yaw) * cos(pitch), sin(pitch), cos(yaw) * cos(pitch))
         * CAM_DISTANCE;
 
     let fwd = normalize(-cam);
-    let right = normalize(cross(vec3<f32>(0.0, 1.0, 0.0), fwd));
-    let up = cross(fwd, right);
+    let level_right = normalize(cross(vec3<f32>(0.0, 1.0, 0.0), fwd));
+    let level_up = cross(fwd, level_right);
+    // Roll the frame about the view axis, so that what is level in the world
+    // runs diagonally across the picture. The tilt slider sets the angle.
+    let right = level_right * cos(u.tilt) - level_up * sin(u.tilt);
+    let up = level_right * sin(u.tilt) + level_up * cos(u.tilt);
 
     var pos = cam;
-    // 1.7 is the focal length: larger is a narrower field of view.
-    var vel = normalize(fwd * 1.7 + right * p.x + up * p.y);
+    var vel = normalize(fwd * FOCAL + right * (p.x - HOLE_OFFSET) + up * p.y);
 
     let rs = max(u.mass, 0.02);
     // The innermost stable circular orbit sits at 3 * rs, so that is where the
@@ -224,6 +277,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     let h2 = dot(hv, hv);
 
     var color = vec3<f32>(0.0);
+    // The bloom, kept apart from the colour until the ray's fate is known:
+    // see below the loop.
+    var halo = vec3<f32>(0.0);
     var escaped = false;
 
     for (var i = 0; i < STEPS; i++) {
@@ -244,10 +300,11 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         // resolved without spending the budget out in the empty part...
         var dt = clamp(0.08 * r, 0.02, 1.0);
         // ...and a shorter one near the disk plane, where the crossing below
-        // is found by interpolating across a single step.
-        if abs(pos.y) < 1.5 && r < DISK_OUTER + 1.0 {
-            dt = min(dt, 0.15);
-        }
+        // is found by interpolating across a single step. The blend is smooth:
+        // a hard switch in the step size prints a seam into the photon ring
+        // wherever an orbit crosses it.
+        let near_disk = smoothstep(2.5, 1.0, abs(pos.y)) * smoothstep(DISK_OUTER + 3.0, DISK_OUTER, r);
+        dt = mix(dt, min(dt, 0.15), near_disk);
 
         // Null geodesics in Schwarzschild, written in Cartesian coordinates: a
         // central pull that falls off as 1/r^5 rather than 1/r^2. Circular
@@ -255,6 +312,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         // thin bright ring that hugs the shadow is light that went round it.
         let acc = -1.5 * h2 * rs * pos / (r2 * r2 * r);
         let next = pos + vel * dt + 0.5 * acc * dt * dt;
+
+        // The bloom, gathered along the way; see `glow`.
+        halo = halo + glow(pos, dt, inner);
 
         // The disk lies in y = 0, so a step that changes the sign of y crossed
         // it. The disk is thin and see-through, and a lensed ray can cross it
@@ -272,6 +332,12 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     if escaped {
         color = color + sky(normalize(vel));
     }
+    // A ray that fell in gathered glow on the way, and near the edge of the
+    // shadow it gathered a lot: it went round and round the photon sphere
+    // first. Keeping all of it would fill the shadow with light, dropping all
+    // of it would cut the halo off dead at the edge. A fraction of it leaves
+    // the shadow a dark haze that brightens towards its rim.
+    color = color + halo * select(0.45, 1.0, escaped) * 0.005 * u.bloom;
 
     var c = tonemap(color);
     // Everything above is linear light. egui takes the surface format the

--- a/examples/shader/src/shader.wgsl
+++ b/examples/shader/src/shader.wgsl
@@ -36,11 +36,10 @@ const STEPS: i32 = 190;
 const DISK_OUTER: f32 = 9.0;
 
 // The framing, before any drag: close in, a few degrees above the disk, the
-// camera rolled so the disk runs up and to the right, and the hole off to the
-// right of centre so the near side of the disk can sweep in from the left.
+// hole in the middle of the picture, and the camera rolled (by the tilt
+// slider) so the disk runs diagonally across it.
 const CAM_DISTANCE: f32 = 10.5;
 const PITCH: f32 = 0.08;
-const HOLE_OFFSET: f32 = 0.6;
 // Larger is a narrower field of view.
 const FOCAL: f32 = 1.5;
 
@@ -264,7 +263,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     let up = level_right * sin(u.tilt) + level_up * cos(u.tilt);
 
     var pos = cam;
-    var vel = normalize(fwd * FOCAL + right * (p.x - HOLE_OFFSET) + up * p.y);
+    var vel = normalize(fwd * FOCAL + right * p.x + up * p.y);
 
     let rs = max(u.mass, 0.02);
     // The innermost stable circular orbit sits at 3 * rs, so that is where the

--- a/examples/shader/src/shader.wgsl
+++ b/examples/shader/src/shader.wgsl
@@ -1,13 +1,32 @@
-// A fullscreen triangle and a plasma, driven by the app's state.
+// A gravitationally lensed black hole, driven by the app's state.
+//
+// One fullscreen triangle, and for every pixel of it a photon traced backwards
+// from the camera through curved space. What the photon runs into on the way —
+// the accretion disk, the sky, or the horizon — is the colour of the pixel.
 
 struct Uniform {
     time: f32,
-    speed: f32,
+    // The Schwarzschild radius in scene units. The slider writes it, and it
+    // sets both the size of the shadow and how hard the light bends.
+    mass: f32,
     resolution: vec2<f32>,
     mouse: vec2<f32>,
+    // 1.0 when egui is drawing into an sRGB surface format, 0.0 when it is
+    // not. `gpu::setup` reads it off the render state; see the end of
+    // `fs_main` for what it is for.
+    srgb_target: f32,
+    _pad: f32,
 };
 
 @group(0) @binding(0) var<uniform> u: Uniform;
+
+// How many integration steps a photon gets before it is given up on. A ray
+// that runs out is one caught in the photon sphere, spiralling; black is the
+// right answer for it anyway.
+const STEPS: i32 = 190;
+// The disk's outer edge, in scene units. Its inner edge follows the mass.
+const DISK_OUTER: f32 = 9.0;
+const CAM_DISTANCE: f32 = 17.0;
 
 struct VertexOut {
     @builtin(position) position: vec4<f32>,
@@ -31,32 +50,236 @@ fn vs_main(@builtin(vertex_index) index: u32) -> VertexOut {
     return out;
 }
 
+fn hash21(p: vec2<f32>) -> f32 {
+    var q = fract(p * vec2<f32>(0.1031, 0.1030));
+    q = q + dot(q, q.yx + 33.33);
+    return fract((q.x + q.y) * q.x);
+}
+
+fn hash31(p: vec3<f32>) -> f32 {
+    var q = fract(p * 0.1031);
+    q = q + dot(q, q.zyx + 31.32);
+    return fract((q.x + q.y) * q.z);
+}
+
+fn noise2(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    // Smoothstep on the cell coordinate, so neighbouring cells meet without a
+    // crease.
+    let w = f * f * (3.0 - 2.0 * f);
+    let a = hash21(i);
+    let b = hash21(i + vec2<f32>(1.0, 0.0));
+    let c = hash21(i + vec2<f32>(0.0, 1.0));
+    let d = hash21(i + vec2<f32>(1.0, 1.0));
+    return mix(mix(a, b, w.x), mix(c, d, w.x), w.y);
+}
+
+fn fbm2(p0: vec2<f32>) -> f32 {
+    var p = p0;
+    var sum = 0.0;
+    var amp = 0.5;
+    for (var i = 0; i < 4; i++) {
+        sum = sum + amp * noise2(p);
+        // An offset with the doubling, so the octaves do not line up on the
+        // lattice and print a grid into the result.
+        p = p * 2.07 + vec2<f32>(1.7, 9.2);
+        amp = amp * 0.5;
+    }
+    return sum;
+}
+
+/// What is behind the hole: stars, and enough nebula to make the lensing
+/// visible on something continuous as well as on the points.
+///
+/// The stars are a hash over a grid of directions rather than a texture. A
+/// cell is lit when its hash lands in the top fraction of a percent, which
+/// puts a few hundred bright ones and a few thousand faint ones on the sphere.
+fn sky(dir: vec3<f32>) -> vec3<f32> {
+    var col = vec3<f32>(0.0);
+    var scale = 130.0;
+    var weight = 2.2;
+    for (var i = 0; i < 2; i++) {
+        let s = dir * scale;
+        let cell = floor(s);
+        let mag = smoothstep(0.994, 1.0, hash31(cell));
+        // Put the star at the centre of its cell and fall off with the
+        // distance to it. Lighting the whole cell instead would draw the
+        // lattice: every star would come out as the same little square.
+        let d = length(s - cell - 0.5);
+        let point = pow(smoothstep(0.62, 0.0, d), 2.5);
+        let tint = hash31(cell + 17.0);
+        let star = mix(vec3<f32>(0.62, 0.76, 1.0), vec3<f32>(1.0, 0.86, 0.62), tint);
+        col = col + star * mag * point * weight;
+        scale = scale * 2.4;
+        weight = weight * 0.3;
+    }
+    // Two noise fields multiplied together, sampled on different pairs of
+    // components so that the result is continuous over the whole sphere and
+    // has no seam to hide. The `smoothstep` is what keeps it a few wisps on
+    // near-black rather than a flat wash over the whole sky.
+    let dust = fbm2(dir.xz * 2.2 + 3.0) * fbm2(dir.yx * 1.9 + 8.0);
+    let cloud = smoothstep(0.22, 0.55, dust);
+    return col + vec3<f32>(0.004, 0.006, 0.018) + vec3<f32>(0.075, 0.045, 0.13) * cloud;
+}
+
+/// One layer of the disk's gas, wound up by `age` seconds of Keplerian shear.
+///
+/// The inner gas laps the outer many times over. Rotating the *sample point*
+/// by an angle that depends on its own radius is what turns plain noise into
+/// spiral arms, and it costs one sin and one cos.
+fn gas(p: vec3<f32>, radius: f32, age: f32) -> f32 {
+    let a = -age * 1.6 / pow(radius, 1.5);
+    let c = cos(a);
+    let s = sin(a);
+    let q = vec2<f32>(p.x * c - p.z * s, p.x * s + p.z * c);
+    return fbm2(q * 1.3) * (0.4 + 0.8 * noise2(q * 3.4));
+}
+
+/// How long a layer of gas is wound before it is started over, in seconds.
+const CHURN: f32 = 7.0;
+
+/// The accretion disk, sampled where a ray crossed the y = 0 plane.
+///
+/// `ray_dir` is the direction the *trace* is travelling, which is the reverse
+/// of the photon's own path — the Doppler term below needs the difference.
+fn disk(p: vec3<f32>, ray_dir: vec3<f32>, t: f32, rs: f32, inner: f32) -> vec3<f32> {
+    let radius = length(p.xz);
+    if radius < inner || radius > DISK_OUTER {
+        return vec3<f32>(0.0);
+    }
+    // 0 at the inner edge, 1 at the outer one.
+    let f = (radius - inner) / (DISK_OUTER - inner);
+
+    // Shear left to itself draws the noise out into ever finer filaments, and
+    // before long into aliased rings. So two layers are wound half a cycle
+    // apart and cross-faded: neither is ever more than half a cycle old, and
+    // each is weighted to zero at the moment it starts over, which is what
+    // hides the restart.
+    let phase = fract(t / CHURN);
+    let w = 1.0 - abs(2.0 * phase - 1.0);
+    let turb = mix(
+        gas(p, radius, fract(phase + 0.5) * CHURN),
+        gas(p, radius, phase * CHURN),
+        w,
+    );
+
+    // Soft at both edges, so the disk does not end on a hard circle.
+    let edge = smoothstep(0.0, 0.09, f) * smoothstep(1.0, 0.72, f);
+    let heat = pow(1.0 - f, 2.6);
+    var col = mix(vec3<f32>(1.0, 0.30, 0.05), vec3<f32>(1.0, 0.95, 0.88), heat);
+
+    // Relativistic beaming. The gas orbits at a good fraction of c, and the
+    // half of the disk turning towards the camera comes out brighter and bluer
+    // than the half turning away. It is what makes a real picture of one
+    // lopsided rather than symmetric, so it is worth the four lines.
+    let beta = clamp(sqrt(rs / (2.0 * radius)), 0.0, 0.8);
+    let tangent = normalize(cross(vec3<f32>(0.0, 1.0, 0.0), p));
+    let approach = dot(tangent, -ray_dir);
+    let doppler = 1.0 / max(1.0 - beta * approach, 0.12);
+    col = mix(col, vec3<f32>(0.72, 0.86, 1.0), clamp((doppler - 1.0) * 0.55, 0.0, 0.55));
+
+    return col * edge * turb * (0.5 + 3.2 * heat) * pow(doppler, 3.0) * 0.55;
+}
+
+/// The filmic curve everyone uses, because the disk is additive and goes well
+/// past 1.0 where it is bright and clipping it would flatten the core to a
+/// disc of pure white.
+fn tonemap(x: vec3<f32>) -> vec3<f32> {
+    let a = x * (2.51 * x + 0.03);
+    let b = x * (2.43 * x + 0.59) + 0.14;
+    return clamp(a / b, vec3<f32>(0.0), vec3<f32>(1.0));
+}
+
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
-    // Square the coordinates up, so the pattern does not stretch with the
-    // window.
+    // Square the coordinates up, so the picture does not stretch with the rect.
     let size = max(u.resolution, vec2<f32>(1.0, 1.0));
-    var uv = vec2<f32>(in.uv.x * size.x / size.y, in.uv.y);
-    // Dragging pushes the pattern around: the drag total arrives in pixels.
-    uv = uv + vec2<f32>(u.mouse.x, -u.mouse.y) / size.y * 2.0;
+    let p = vec2<f32>(in.uv.x * size.x / size.y, in.uv.y);
 
-    let t = u.time;
-    let r = length(uv);
-    // Four waves out of step with each other, so the colours drift apart
-    // instead of moving as one grey pulse.
-    var v = sin(uv.x * 4.0 + t);
-    v = v + sin(uv.y * 4.0 - t * 1.3);
-    v = v + sin((uv.x + uv.y) * 3.0 + t * 0.7);
-    v = v + sin(r * 8.0 - t * 2.0);
-    v = v * 0.25;
+    // Dragging orbits the camera: the drag total arrives in pixels. The pitch
+    // starts just above the disk plane, which is the angle that shows both the
+    // far side lensed over the top and the near side under the shadow.
+    let yaw = u.mouse.x / size.y * 2.4;
+    let pitch = clamp(0.15 + u.mouse.y / size.y * 2.4, -1.45, 1.45);
+    let cam = vec3<f32>(sin(yaw) * cos(pitch), sin(pitch), cos(yaw) * cos(pitch))
+        * CAM_DISTANCE;
 
-    // The slider shows up in the picture as well as in the pace: a faster
-    // setting is a warmer one, so a paused canvas still reacts to it.
-    let warmth = clamp(u.speed * 0.25, 0.0, 1.0);
-    let color = vec3<f32>(
-        0.5 + 0.5 * sin(v * 3.14159 + warmth * 2.0),
-        0.5 + 0.5 * sin(v * 3.14159 + 2.094),
-        0.5 + 0.5 * sin(v * 3.14159 + 4.188 - warmth),
-    );
-    return vec4<f32>(color, 1.0);
+    let fwd = normalize(-cam);
+    let right = normalize(cross(vec3<f32>(0.0, 1.0, 0.0), fwd));
+    let up = cross(fwd, right);
+
+    var pos = cam;
+    // 1.7 is the focal length: larger is a narrower field of view.
+    var vel = normalize(fwd * 1.7 + right * p.x + up * p.y);
+
+    let rs = max(u.mass, 0.02);
+    // The innermost stable circular orbit sits at 3 * rs, so that is where the
+    // gas can start. A heavier hole eats into the disk from the inside.
+    let inner = min(3.0 * rs, DISK_OUTER * 0.8);
+
+    // Angular momentum. The pull below is central, so this is conserved along
+    // the whole path and can be computed once.
+    let hv = cross(pos, vel);
+    let h2 = dot(hv, hv);
+
+    var color = vec3<f32>(0.0);
+    var escaped = false;
+
+    for (var i = 0; i < STEPS; i++) {
+        let r2 = dot(pos, pos);
+        let r = sqrt(r2);
+        // Through the horizon: nothing comes back out, so the pixel keeps
+        // whatever the disk gave it on the way in and gets no sky.
+        if r < rs {
+            break;
+        }
+        // Outbound and far enough that nothing left can bend it back.
+        if r > 22.0 && dot(pos, vel) > 0.0 {
+            escaped = true;
+            break;
+        }
+
+        // A step that shrinks as the ray falls in, so the turn near the hole is
+        // resolved without spending the budget out in the empty part...
+        var dt = clamp(0.08 * r, 0.02, 1.0);
+        // ...and a shorter one near the disk plane, where the crossing below
+        // is found by interpolating across a single step.
+        if abs(pos.y) < 1.5 && r < DISK_OUTER + 1.0 {
+            dt = min(dt, 0.15);
+        }
+
+        // Null geodesics in Schwarzschild, written in Cartesian coordinates: a
+        // central pull that falls off as 1/r^5 rather than 1/r^2. Circular
+        // motion under it needs r = 1.5 * rs, which is the photon sphere — the
+        // thin bright ring that hugs the shadow is light that went round it.
+        let acc = -1.5 * h2 * rs * pos / (r2 * r2 * r);
+        let next = pos + vel * dt + 0.5 * acc * dt * dt;
+
+        // The disk lies in y = 0, so a step that changes the sign of y crossed
+        // it. The disk is thin and see-through, and a lensed ray can cross it
+        // three or four times; the crossings add up, which is what draws the
+        // far side of the disk above and below the shadow.
+        if (pos.y < 0.0) != (next.y < 0.0) {
+            let k = pos.y / (pos.y - next.y);
+            color = color + disk(mix(pos, next, k), normalize(vel), u.time, rs, inner);
+        }
+
+        vel = vel + acc * dt;
+        pos = next;
+    }
+
+    if escaped {
+        color = color + sky(normalize(vel));
+    }
+
+    var c = tonemap(color);
+    // Everything above is linear light. egui takes the surface format the
+    // browser or the window system offers, and only an sRGB one has the
+    // hardware encode on write; for the rest the shader has to do it, or the
+    // disk comes out looking like soot.
+    if u.srgb_target < 0.5 {
+        c = pow(c, vec3<f32>(1.0 / 2.2));
+    }
+    return vec4<f32>(c, 1.0);
 }

--- a/examples/shader/src/shader.wgsl
+++ b/examples/shader/src/shader.wgsl
@@ -113,18 +113,19 @@ fn fbm2(p0: vec2<f32>) -> f32 {
 fn sky(dir: vec3<f32>) -> vec3<f32> {
     var col = vec3<f32>(0.0);
     var scale = 130.0;
-    var weight = 1.4;
+    var weight = 1.8;
     for (var i = 0; i < 2; i++) {
         let s = dir * scale;
         let cell = floor(s);
-        let mag = smoothstep(0.994, 1.0, hash31(cell));
+        let mag = smoothstep(0.986, 1.0, hash31(cell));
         // Put the star at the centre of its cell and fall off with the
         // distance to it. Lighting the whole cell instead would draw the
         // lattice: every star would come out as the same little square.
         let d = length(s - cell - 0.5);
         let point = pow(smoothstep(0.62, 0.0, d), 2.5);
         let tint = hash31(cell + 17.0);
-        let star = mix(vec3<f32>(0.62, 0.76, 1.0), vec3<f32>(1.0, 0.86, 0.62), tint);
+        // Blue-white through to a pale cream: cool, with only a few warm ones.
+        let star = mix(vec3<f32>(0.55, 0.70, 1.0), vec3<f32>(0.95, 0.93, 0.85), tint * tint);
         col = col + star * mag * point * weight;
         scale = scale * 2.4;
         weight = weight * 0.3;
@@ -135,7 +136,7 @@ fn sky(dir: vec3<f32>) -> vec3<f32> {
     // near-black rather than a flat wash over the whole sky.
     let dust = fbm2(dir.xz * 2.2 + 3.0) * fbm2(dir.yx * 1.9 + 8.0);
     let cloud = smoothstep(0.22, 0.55, dust);
-    return col + vec3<f32>(0.008, 0.006, 0.006) + vec3<f32>(0.05, 0.03, 0.025) * cloud;
+    return col + vec3<f32>(0.004, 0.006, 0.016) + vec3<f32>(0.03, 0.045, 0.11) * cloud;
 }
 
 /// One layer of the disk's gas, wound up by `age` seconds of Keplerian shear.

--- a/examples/shader/tests/app.rs
+++ b/examples/shader/tests/app.rs
@@ -1,4 +1,5 @@
-//! Plan test C-2: the slider moves `speed`, and `pause` stops the repaints.
+//! Plan test C-2: the sliders move their state, and `pause` stops the
+//! repaints.
 //!
 //! Headless, like every other example test. The `<Canvas>` pushes an
 //! `egui_wgpu::Callback` onto the painter, but the harness's default renderer
@@ -31,34 +32,66 @@ fn harness<'a>() -> Harness<'a, Store> {
         )
 }
 
-/// The slider's own reading. The canvas has no text to check, so the value is
+/// A slider's own reading. The canvas has no text to check, so the value is
 /// read from the accessibility tree rather than from the picture.
-fn speed(harness: &Harness<'_, Store>) -> f64 {
+///
+/// There are two sliders now, so the role alone no longer picks one out;
+/// `<Slider label>` becomes the node's name, which does.
+fn slider_value(harness: &Harness<'_, Store>, label: &str) -> f64 {
     harness
-        .get_by_role(egui::accesskit::Role::Slider)
+        .get_by_role_and_label(egui::accesskit::Role::Slider, label)
         .accesskit_node()
         .numeric_value()
-        .expect("the speed slider should report its value")
+        .unwrap_or_else(|| panic!("the {label} slider should report its value"))
+}
+
+/// Focus a slider and nudge it right. Dragging is fiddly headless; focusing and
+/// nudging is the stable way.
+fn nudge(harness: &mut Harness<'_, Store>, label: &str) {
+    harness
+        .get_by_role_and_label(egui::accesskit::Role::Slider, label)
+        .focus();
+    harness.step();
+    harness.key_press(egui::Key::ArrowRight);
+    // One pass to apply the write, one to draw with it.
+    harness.step();
+    harness.step();
 }
 
 #[test]
 fn the_slider_moves_the_speed() {
     let mut harness = harness();
     harness.step();
-    assert_eq!(speed(&harness), 1.0);
+    assert_eq!(slider_value(&harness, "speed"), 1.0);
 
-    // Dragging is fiddly headless; focusing and nudging is the stable way.
-    harness.get_by_role(egui::accesskit::Role::Slider).focus();
-    harness.step();
-    harness.key_press(egui::Key::ArrowRight);
-    // One pass to apply the write, one to draw with it.
-    harness.step();
-    harness.step();
+    nudge(&mut harness, "speed");
 
     assert!(
-        speed(&harness) > 1.0,
+        slider_value(&harness, "speed") > 1.0,
         "the slider did not change the speed: {}",
-        speed(&harness),
+        slider_value(&harness, "speed"),
+    );
+}
+
+/// The second slider is wired the same way, and moving it must not disturb the
+/// first: two `use_state` hooks in one component, each with its own slot.
+#[test]
+fn the_other_slider_moves_the_mass_and_nothing_else() {
+    let mut harness = harness();
+    harness.step();
+    let before = slider_value(&harness, "mass");
+
+    nudge(&mut harness, "mass");
+
+    assert!(
+        slider_value(&harness, "mass") > before,
+        "the slider did not change the mass: {}",
+        slider_value(&harness, "mass"),
+    );
+    assert_eq!(
+        slider_value(&harness, "speed"),
+        1.0,
+        "moving the mass slider moved the speed as well",
     );
 }
 
@@ -101,7 +134,9 @@ fn the_controls_stay_below_the_canvas() {
     let mut harness = harness();
     harness.step();
 
-    let slider = harness.get_by_role(egui::accesskit::Role::Slider).rect();
+    let slider = harness
+        .get_by_role_and_label(egui::accesskit::Role::Slider, "speed")
+        .rect();
     let pause = harness.get_by_label("pause").rect();
     assert!(
         slider.bottom() <= HEIGHT && pause.bottom() <= HEIGHT,


### PR DESCRIPTION
This PR replaces the plasma pattern shader example with a physically-based ray-traced black hole visualization. The new shader traces photons backwards from the camera through curved spacetime, rendering the accretion disk, gravitational lensing effects, and the event horizon.

## Key Changes

- **Shader rewrite**: Replaced the simple plasma pattern with a Schwarzschild black hole ray tracer that:
  - Traces null geodesics (photon paths) through curved spacetime
  - Renders an accretion disk with relativistic beaming and Keplerian shear
  - Generates a procedural starfield and nebula for the background sky
  - Applies proper tonemapping and sRGB gamma correction
  
- **Uniform buffer changes**: 
  - Replaced `speed` uniform with `mass` (Schwarzschild radius in scene units)
  - Added `srgb_target` flag to handle linear-to-sRGB conversion based on render target format
  - Adjusted padding to maintain buffer alignment

- **UI updates**:
  - Added a second slider for the `mass` parameter (controls black hole size)
  - Updated instructions from "move the pattern" to "orbit the camera"
  - Updated summary and documentation to reflect the new visualization

- **Test updates**:
  - Refactored slider access to use label-based lookup (now that there are two sliders)
  - Added new test `the_other_slider_moves_the_mass_and_nothing_else` to verify independent slider state
  - Updated existing test to use the new slider lookup mechanism

- **Documentation**: Enhanced module and function documentation to explain the physics and implementation details of the ray tracer

The implementation demonstrates how complex GPU computations can be driven by simple egui state hooks, with the shader handling all the mathematical complexity while the Rust code remains straightforward.

https://claude.ai/code/session_01NdGAtm578CgPPoFH1Z9beE