### PR TITLE
docs: compact layout for phones, with a header and a sliding menu

### DIFF
--- a/docs/tasks/layout/plan.md
+++ b/docs/tasks/layout/plan.md
@@ -1,0 +1,263 @@
+# Plan: overlays without the escape hatch
+
+The task is in [task.md](task.md). Everything here replaces something the
+gallery does by hand today; the "before" is `examples/gallery/src/lib.rs` at
+the end of PR #15 (`PaneToggle`, `Menu`, and the `match showing` in `App`).
+
+## 0. What the hatches do, and what replaces each
+
+| Today | Replacement | Section |
+|---|---|---|
+| `egui::Area::new(id).order(Foreground).anchor(RIGHT_BOTTOM, (-16, -16))` | `<Overlay anchor="right-bottom" offset={(-16.0, -16.0)}>` | 1 |
+| `egui::Area::new(id).fixed_pos(..).constrain(false).default_size(screen)` + `ctx.move_to_top` + `rect_filled` + `allocate_rect(.., Sense::click())` + `Cx::new` + `root_container` | `<Overlay pos={..} constrain={false} top w="100%" h="100%" fill={..}>` | 1 |
+| `ctx.animate_bool_with_time_and_easing(scope.with("slide"), open, 0.25, cubic_out)` | `use_animate(cx, open, 0.25)` | 2 |
+| `egui::Frame::new().shadow(visuals.window_shadow).corner_radius(24)` | `<Frame shadow corner_radius={24.0}>` | 3 |
+| `ui.spacing_mut().button_padding = ..; egui::Button::new(..).corner_radius(24)` + `accesskit_node_builder` | `<Button label=".." padding={(16.0, 12.0)} corner_radius={24.0}>` | 3 |
+| `match showing { Example => <View key>.., Code => <Code> }` (unmounts the example) | both mounted, one under `<View display="none">` | 4 |
+
+## 1. `<Overlay>`
+
+### Shape
+
+```rust
+#[component]
+pub fn Overlay(
+    cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,   // only `w` / `h` are read
+    #[prop(into)] anchor: Option<Anchor>, // "left-top" .. "right-bottom", "center"
+    #[prop(default)] offset: (f32, f32),  // from the anchor, in points
+    pos: Option<egui::Pos2>,              // instead of `anchor`: the top-left corner
+    #[prop(default, into)] order: Order,  // "background" | "middle" | "foreground" | "tooltip"; default "foreground"
+    #[prop(default = true)] constrain: bool,
+    #[prop(default)] top: bool,           // `move_to_top` every frame
+    fill: Option<egui::Color32>,
+    children: impl View,
+)
+```
+
+`Anchor` and `Order` are `str_enum!`s in `egui_react::layout`, next to
+`Direction`, so `rsx!` takes the string spellings. `Order` maps onto
+`egui::Order`; `Anchor` onto `egui::Align2`.
+
+### Behaviour
+
+Same skeleton as `<Window>`: the `Area` is keyed by `cx.scope_id()`, shown
+against `cx.ctx()`, and takes no room from the parent. Inside `show`:
+
+- **Sized** (`w` and/or `h` given): the sheet is
+  `Rect::from_min_size(ui.max_rect().min, size)`, where a `Percent` is of
+  `ctx.content_rect()` and an `Auto` axis is the content's. `fill` paints the
+  sheet first. `ui.allocate_rect(sheet, Sense::click())` makes the area that
+  size and takes the presses. Then a child `Ui` with `max_rect(sheet)` and
+  `Cx::new(store, ui, scope)` + `root_container(scope.with("overlay"),
+  root_style(), ..)`, so the children see a column that fills the sheet and
+  `grow` works in it. `root_style()` moves from `egui-react-app` to
+  `egui_react::layout` (or is rebuilt inline: column, `w 100% h 100%`) so the
+  elements crate does not depend on the app crate.
+- **Unsized**: `Cx::new(store, ui, scope)` and `children.show(cx)` in plain
+  `Ui` mode, as `<Window>` does. The area is as big as what it draws.
+
+`top` calls `ctx.move_to_top(LayerId::new(order, id))` before `show`. egui
+keeps areas in first-shown order within an `Order`, and a click brings one
+forward, so an overlay that must stay above another one drawn in the same
+frame has to ask every frame. The gallery's menu is the case: the toggle's
+area exists first.
+
+`constrain={false}` lets `pos` be above or beside the window, which is what
+a slide from an edge is. egui clips the area to the window either way.
+
+Not drawing an `<Overlay>` (the `if open { <Overlay> }` pattern) unmounts
+its children through the ordinary sweep, since their scopes are not visited.
+The `Area`'s own state (`AreaState`) is egui's and stays; that is fine, it is
+only the last position and size.
+
+### Tests (`crates/egui-react-elements/tests/overlay.rs`)
+
+- Anchored: `<Overlay anchor="right-bottom" offset={(-16, -16)}><Button/>`
+  in a 400x800 harness; the button's rect is inside the bottom-right quarter,
+  and stays there when the tree around it draws a tall `<View>`.
+- Sized and covering: a `<Button label="under">` in the tree and
+  `<Overlay w="100%" h="100%" fill={..}>` over it; pressing at the button's
+  centre (hover / drag / drop, as the gallery test does) fires nothing.
+- Filling: with `w="100%" h="100%"`, a `<ScrollArea grow={1.0}>` inside the
+  overlay reaches the bottom of the window (its rect's bottom is the window's).
+- Unmount: a `use_state` counter inside an overlay that is drawn, then not,
+  then drawn again starts over.
+- `top`: two overlays in the same `Order`, the second with `top`; a press at a
+  point they share reaches the second.
+
+## 2. `use_animate`
+
+```rust
+#[track_caller]
+pub fn use_animate(cx: &mut Cx<'_, '_>, on: bool, time: f32) -> f32
+```
+
+Keyed like `use_state` (`scope_id().with(location_key(location))`) and
+implemented as `cx.ctx().animate_bool_with_time_and_easing(id, on, time,
+easing::cubic_out)`. egui's `AnimationManager` owns the value and requests
+the repaints while it moves, so nothing is stored in the `Store` and the
+repaint policy (ARCHITECTURE 5.6) is untouched. A `use_animate_with(cx, on,
+time, easing)` takes the easing for the callers that want another; the
+default is the one the gallery uses.
+
+No `Store` slot means no sweep either: an animation of a component that
+stops being drawn stays in egui's memory at its last value, which is what
+`animate_bool` does for everyone. Documented, not fixed.
+
+Test (`crates/egui-react/tests/animate.rs`, kittest with `step_dt` 0.05):
+the value is 0 on the first frame with `on = false`; after flipping, it is
+strictly increasing over the next `time / step_dt` steps and 1 after; with
+`time = 0` it is 1 on the frame after the flip.
+
+## 3. `<Frame shadow>` and `<Button padding corner_radius>`
+
+- `Frame` gets `#[prop(default)] shadow: bool`, which picks
+  `visuals.window_shadow` inside the leaf, so `<Frame shadow>` needs no
+  `Context` in the caller. A `custom_shadow: Option<egui::Shadow>` is there
+  for anyone who wants their own; it wins over `shadow`.
+- `Button` gets `padding: Option<(f32, f32)>` (sets
+  `ui.spacing_mut().button_padding` on the leaf's `Ui`, which is a child `Ui`
+  so nothing leaks) and `corner_radius: Option<f32>` (`egui::Button::corner_radius`).
+  Text size is already the children's business (`RichText::new("</>").size(18.0)`
+  is a `WidgetText`).
+
+Tests in the existing `tests/widgets.rs` / `tests/containers.rs`: a padded
+button is wider and taller than the same button without by twice the padding;
+a shadowed frame's shapes include a shadow mesh (or, simpler, the frame's
+outer rect is the same and the test only checks it still lays out). The
+snapshot tests in `elements` are where the picture is checked, if a GPU is
+around.
+
+## 4. `display="none"` on the taffy path
+
+### Today
+
+`<View display="none">` sets `taffy::Display::None` on the node, and taffy
+lays it out at zero. But `TreeCx::leaf` still opens a `Ui` at the zero rect
+and runs the closure, so a widget draws (a label spills out of a zero rect;
+egui does not clip to the `Ui`), registers with accesskit, and takes input if
+the pointer is over its overflow. `TreeCx::text` paints its galley. The lite
+path (`lite.rs`, `compute`) already short-circuits: `hide(node)` and
+`Sz::ZERO`, and its `paint` skips hidden subtrees.
+
+### Change
+
+`TreeCx` gets a `hidden: bool`, set in `container` when
+`style.display == taffy::Display::None`, inherited by children the way
+`placed` is. While hidden:
+
+- `container`: still adds the node (keys and indices must stay stable, or
+  the show after a hide would be a "created this frame" pass) and runs `f`,
+  so components run and hooks live.
+- `leaf`: adds the node and runs `f` in a `Ui` built with
+  `UiBuilder::new().sizing_pass().invisible()` at the zero rect, the way a
+  first-frame measurement already runs. That draws nothing, registers no
+  accesskit node, and takes no input (a sizing pass is not interactive), so a
+  hidden button is not clickable. It still returns `R`, which is why the
+  closure runs at all: `Cx::leaf` returns `R` and callers such as `Button`
+  read it, and skipping `f` would mean changing that signature for every
+  element.
+- `text`: adds the node and skips both paint paths and the widget rect (no
+  accesskit node, no selection).
+- The measure of a hidden leaf is not written (taffy ignores it anyway).
+
+`Tree::paint_texts` skips hidden nodes, which it can tell from the style.
+
+### Parity
+
+`tests/lite_parity.rs` gets a case with a hidden `<View>` in a row: both
+paths give the row the same size and neither reports the hidden `<Text>`.
+A test in `crates/egui-react/tests/` (`hidden.rs`): a `use_state` counter
+inside a hidden `<View>` keeps its value after the view is hidden for a
+frame and shown again; `query_by_label` on the hidden text is `None`; the
+hidden view's siblings are laid out as if it were absent.
+
+### Gallery
+
+```rust
+<View display={if showing == Pane::Example { "flex" } else { "none" }} key={current.name} ..>
+    <Running ../>
+</View>
+<Code display=.. />   // `Code` takes `style`; `display` is a container prop,
+                      // so `Code`'s outer `<View>` takes a `display` prop too
+```
+
+The example keeps running while the code is up: a `clock` keeps time, a
+`todo` keeps its draft. That is what a phone user expects of a tab.
+
+## 5. The gallery afterwards
+
+```rust
+if !open {
+    <Overlay anchor="right-bottom" offset={(-16.0, -16.0)}>
+        <Frame shadow corner_radius={24.0}>
+            <Button label={label} padding={(16.0, 12.0)} corner_radius={24.0}
+                    on_click={|| *pane = next}>
+                {RichText::new(glyph).size(18.0)}
+            </Button>
+        </Frame>
+    </Overlay>
+}
+```
+
+```rust
+let down = use_animate(cx, open, MENU_TIME);
+if down > 0.0 {
+    let screen = cx.ctx().content_rect();
+    <Overlay pos={pos2(0.0, screen.top() - screen.height() * (1.0 - down))}
+             constrain={false} top w="100%" h="100%" fill={panel_fill}>
+        <View direction="column" gap={8} w="100%" h="100%" p={8}>
+            ..header row.., <List w="100%" grow={1.0} min_h={0.0} ../>
+        </View>
+    </Overlay>
+}
+```
+
+`content_rect()` stays: it is where the window size comes from, and the
+compact/wide decision needs it too. `panel_fill` is
+`cx.ctx().style().visuals.panel_fill`; an `<Overlay fill>` default of
+`panel_fill` when `w`/`h` are given would remove that read as well.
+
+The tests in `examples/gallery/tests/gallery.rs` do not change: they find
+`menu`, `close menu`, `show code`, `show example`, `examples` by label and
+press where the `new` button was. `the_menu_covers_the_pane` is exactly the
+`<Overlay>` covering test, one level up.
+
+## 6. Docs
+
+- ARCHITECTURE 6, elements table, Containers: `Overlay` (`anchor` / `offset`
+  / `pos` / `order` / `constrain` / `top` / `fill`; sized by `w` / `h`, or by
+  its children).
+- ARCHITECTURE 4, hooks list: `use_animate`.
+- ARCHITECTURE 6, Layout: `display="none"` hides the subtree on both paths;
+  the components inside still run.
+- `docs/tasks/layout/task.md`: the result table, as the other tasks do.
+
+## 7. Order
+
+One PR, one commit per row; each row leaves `cargo test --workspace` green.
+
+1. `use_animate` (no dependants, smallest).
+2. `<Frame shadow>`, `<Button padding corner_radius>`.
+3. `<Overlay>` and its tests.
+4. Gallery: `PaneToggle` and `Menu` on top of 1-3. `grep` for `egui::Area`
+   and `Cx::new` in `lib.rs` is empty after this commit.
+5. `display="none"` on the taffy path, parity test, and the gallery keeping
+   the example mounted.
+
+Step 5 is the one that touches the engine. If it grows (the `leaf` return
+value, or `paint_texts`), it moves to a PR of its own and steps 1-4 ship
+without it; the gallery is no worse than today in the meantime.
+
+## 8. Open questions
+
+- `Anchor` spellings: `"right-bottom"` (egui's `Align2` order) or CSS-ish
+  `"bottom-right"`? The rest of `layout.rs` follows CSS (`"space-between"`),
+  so CSS-ish, with egui's order accepted as well.
+- Should a sized `<Overlay>` default `fill` to `panel_fill`? A full-window
+  sheet is always painted; a corner button never is. Default to "painted when
+  sized", overridable with `fill={Color32::TRANSPARENT}`.
+- Percent `w` / `h` on an overlay are of the window. Of the parent tree's
+  root would be another reading; the window is what a floating thing is
+  placed in, so the window.

--- a/docs/tasks/layout/task.md
+++ b/docs/tasks/layout/task.md
@@ -1,0 +1,100 @@
+# Task: overlays without the escape hatch
+
+## Background
+
+The gallery's compact layout (PR #15, `examples/gallery/src/lib.rs`) puts two
+things over the page: a button floating in the bottom-right corner that swaps
+the running example for its code, and a menu that slides down over the whole
+window. Neither can be a node of the flex tree, because both sit *over* the
+tree rather than in it, so both are written against egui directly:
+
+| Where | What is called | Why the elements could not do it |
+|---|---|---|
+| `PaneToggle` | `egui::Area` anchored `RIGHT_BOTTOM`, `egui::Frame` with a shadow, a raw `egui::Button` with its own padding and corner radius, `accesskit_node_builder` for the label | No element floats; `<Frame>` has no `shadow`; `<Button>` has no `padding` / `corner_radius` |
+| `Menu` | `egui::Area` at a `fixed_pos` partly above the window (`constrain(false)`), `ctx.animate_bool_with_time_and_easing` for the slide, `ctx.move_to_top` to stay above the toggle, `allocate_rect(.., Sense::click())` so the pane beneath gets no presses, then `Cx::new` + `root_container` to get back into the tree | Same, plus no hook wraps egui's animation, and nothing re-enters the tree for the caller |
+| `App` | Switching to the code pane unmounts the example, so it starts over when it comes back | `display="none"` is only honoured on the lite path (`engine/lite.rs`); the taffy engine still draws a hidden subtree into a zero rect |
+
+The first two rows are the same shape as `<Window>` (`containers.rs`): an egui
+container that is anchored to the `Context`, not to the parent, with children
+that re-enter through a fresh `Cx`. There is no element for the general case,
+and that is the gap. The third row is a separate limitation of the engine that
+the same page runs into.
+
+Two older hatches in the gallery are **not** this task: `Chip` draws
+`ui.selectable_label` because no element shows a pressed state, and the code
+pane draws `Label::new(Arc<Galley>)` per line because `<Label>` takes
+`WidgetText` only. Both are widget gaps, not layout ones.
+
+## Goal
+
+The gallery's `lib.rs` has no `egui::Area`, no `Cx::new`, and reads
+`cx.ctx()` for nothing but `content_rect()` (the width that picks the
+layout). Everything the two overlays do is done with elements and hooks that
+any app can use.
+
+## Scope
+
+### In scope
+
+- `<Overlay>` (`egui-react-elements`): an `egui::Area` as an element. Where
+  it sits (`anchor` + `offset`, or `pos`), which layer (`order`), whether it
+  may leave the window (`constrain`), whether it stays on top (`top`), and a
+  `fill`. With `w` / `h` the children get a tree of their own that fills the
+  sheet, rooted the way the runner roots the app; without, they size the
+  sheet, as in `<Window>`. The sheet swallows the presses that would reach
+  what is under it.
+- `use_animate` (`egui-react`): `ctx.animate_bool_with_time_and_easing`
+  behind a hook keyed by the call site, so a component gets "0 when off, 1
+  when on, in between on the way" without touching the `Context`.
+- `<Frame shadow>` and `<Button padding corner_radius>`: the two props the
+  floating button needed.
+- `display="none"` on the taffy path: a hidden `<View>` takes no space, draws
+  nothing and reports nothing to accesskit, while the components inside keep
+  running so their hooks survive. The gallery then keeps the example mounted
+  while its code is up.
+- The gallery rewritten on top of these, with its tests unchanged (they query
+  labels, not implementation).
+- ARCHITECTURE: `Overlay` in the elements table, `use_animate` in the hooks
+  list, `display="none"` under Layout.
+
+### Out of scope
+
+- `position: absolute` / `inset` on `ItemStyle`. taffy supports it, but an
+  absolute node is still in the parent's egui layer: nothing guarantees it
+  paints over an example's own `ScrollArea`, and a sheet sliding in from
+  above the window has nowhere to be clipped. The `Area` is the right tool
+  for both overlays; absolute positioning can come later for the "badge in
+  the corner of a card" case, on its own task.
+- Toggle buttons and galley labels (the older hatches above).
+- Touch gestures (swipe to close the menu). When someone asks.
+
+## Deliverables
+
+- `crates/egui-react-elements/src/containers.rs`: `Overlay`, `Frame::shadow`;
+  `widgets.rs`: `Button::padding` / `corner_radius`.
+  `tests/overlay.rs` with kittest.
+- `crates/egui-react/src/hooks.rs`: `use_animate`. `tests/animate.rs`.
+- `crates/egui-react/src/engine/mod.rs`: hidden subtrees. A test next to
+  `tests/lite_parity.rs`, so both paths agree on what "hidden" means.
+- `examples/gallery/src/lib.rs` without the hatches.
+- ARCHITECTURE sections 4 and 6.
+
+Details and the order of work are in [plan.md](plan.md).
+
+## Done criteria
+
+- kittest: an `<Overlay anchor="right-bottom">` reports a rect inside the
+  window's bottom-right quarter whatever the tree around it draws; an overlay
+  with `w="100%" h="100%"` covers the window and a press on a button under it
+  does not reach the button; children of an overlay that is not drawn are
+  unmounted (their hooks are gone on the next pass).
+- kittest: `use_animate` goes from 0 to 1 over `time` seconds of
+  `Harness::step`s after the target flips, and is 1 at once when `time` is 0.
+- kittest: a `<View display="none">` has zero size, its `<Text>` is not in
+  the accesskit tree, and a `use_state` inside it keeps its value across the
+  hide and the show.
+- `cargo test -p gallery` passes unchanged, and `grep -c "egui::Area\|Cx::new" examples/gallery/src/lib.rs` is 0.
+- The gallery on a phone (`trunk serve`, or the PR preview) looks and moves as
+  it does at the end of PR #15: the toggle in the corner, the menu sliding
+  down and back up, and the example still holding its state after a trip to
+  the code pane.

--- a/examples/gallery/src/lib.rs
+++ b/examples/gallery/src/lib.rs
@@ -1,15 +1,21 @@
 //! Every example, its code and a tag filter, in one binary.
 //!
-//! Three flex columns and no `Panel`: the gallery follows the same rule it
-//! imposes on the examples it embeds, so the centre column can hand an example
-//! an area to fill. Switching examples changes the `key` on that column, which
-//! makes the previous example's hooks unreachable; the pass-end sweep drops
-//! them and the new example starts clean.
+//! A header and three flex columns, and no `Panel`: the gallery follows the
+//! same rule it imposes on the examples it embeds, so the centre column can
+//! hand an example an area to fill. Switching examples changes the `key` on
+//! that column, which makes the previous example's hooks unreachable; the
+//! pass-end sweep drops them and the new example starts clean.
+//!
+//! Under [`COMPACT_WIDTH`] (a phone) there is no room for three columns, so
+//! the page is one pane: the example or its code, swapped by a button floating
+//! in the bottom-right corner. The list and the tag filter move into a menu
+//! that slides down over the whole window from the button in the header.
 
 use std::sync::Arc;
 
 mod highlight;
 use egui_react::prelude::*;
+use egui_react_app::root_style;
 use egui_react_elements::prelude::*;
 use example_meta::Meta;
 
@@ -54,17 +60,44 @@ pub const EXAMPLES: &[Meta] = &[
 /// Where the source links point.
 const REPO: &str = "https://github.com/fand/egui-react/blob/main/examples";
 
-/// The gallery: list, running example, code.
+/// Below this window width the gallery is one pane and a menu rather than
+/// three columns.
+///
+/// The columns need 200 points for the list, 360 for the code and something
+/// left over for the example; a phone in portrait has about 400 in all, and a
+/// tablet on its side has more than this.
+pub const COMPACT_WIDTH: f32 = 720.0;
+
+/// How long the menu takes to slide down, or back up, in seconds.
+const MENU_TIME: f32 = 0.25;
+
+/// What the compact layout shows: the running example, or its code.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Pane {
+    /// The running example.
+    #[default]
+    Example,
+    /// The example's source.
+    Code,
+}
+
+/// The gallery: header, list, running example, code.
 ///
 /// `start` is the example to open first; [`initial_example`] is where the
 /// runner gets it. It is a prop and not something the component reads for
 /// itself, because reading the process arguments here would make the gallery
 /// open a different example under `cargo test <filter>`.
+///
+/// The layout follows the window: three columns above [`COMPACT_WIDTH`], one
+/// pane and a menu below it. The states are the same either way, so turning a
+/// phone keeps the example, the filter and the version that was picked.
 #[component]
 pub fn App(cx: &mut Cx, #[prop(default = EXAMPLES[0].name)] start: &'static str) {
     let mut selected = use_state(cx, move || start);
     let mut tags = use_state(cx, Vec::<&'static str>::new);
     let mut plain = use_state(cx, || false);
+    let mut pane = use_state(cx, Pane::default);
+    let mut menu_open = use_state(cx, || false);
 
     // Read the states once, so the handlers below are free to take them `&mut`
     // without tripping over a live borrow.
@@ -77,54 +110,268 @@ pub fn App(cx: &mut Cx, #[prop(default = EXAMPLES[0].name)] start: &'static str)
         .iter()
         .filter(|meta| matches_tags(meta, &active))
         .collect();
+    let compact = cx.ctx().content_rect().width() < COMPACT_WIDTH;
+    // A menu left open when the window widens is simply gone: the list is a
+    // column again.
+    let open = compact && *menu_open;
+    let showing: Pane = *pane;
 
     // Keep `#todo` in the address bar in step with the selection.
     use_effect(cx, current.name, || set_hash(current.name));
 
     rsx! {
-        <View direction="row" grow={1.0} gap={8}>
-            <List
-                shown={&shown}
-                active={&active}
-                selected={current.name}
-                on_select={|name: &'static str| {
-                    *selected = name;
-                    // A new example starts on its egui-react version.
-                    *plain = false;
-                }}
-                on_tag={|tag: &'static str| toggle(&mut tags, tag)}
-                on_clear={|| tags.clear()}
-            />
-            <Separator vertical/>
-            // `min_w={0}` makes the centre the column that gives way: taffy
-            // may otherwise take a flex item's content as its automatic
-            // minimum, and a wide example would push the code column off the
-            // right edge instead of being cut off itself.
-            <View direction="column" grow={1.0} min_w={0.0} gap={4}>
-                // The summary, not the name: the name is already the label of
-                // the list button and two widgets with one label are ambiguous
-                // to a screen reader (and to kittest).
-                <Text strong>{current.summary}</Text>
-                // The `key` is the whole point: change it and the previous
-                // example's hooks are swept, so state does not leak across.
-                <View key={current.name} direction="column" grow={1.0}>
-                    <Running name={current.name} plain={showing_plain}/>
+        <View direction="column" grow={1.0} min_h={0.0} gap={8}>
+            <Header compact={compact} on_menu={|| *menu_open = !*menu_open}/>
+            if compact {
+                // One pane, and the summary above it whichever it is.
+                <View direction="column" grow={1.0} min_h={0.0} gap={4}>
+                    <Text strong wrap>{current.summary}</Text>
+                    match showing {
+                        // The same `key` as the wide layout: switching
+                        // examples sweeps the previous one's hooks. Switching
+                        // to the code does too, so the example starts over
+                        // when it comes back.
+                        Pane::Example => {
+                            <View key={current.name} direction="column" grow={1.0} min_h={0.0}>
+                                <Running name={current.name} plain={showing_plain}/>
+                            </View>
+                        }
+                        Pane::Code => {
+                            <Code
+                                w="100%"
+                                grow={1.0}
+                                min_h={0.0}
+                                meta={*current}
+                                plain={showing_plain}
+                                on_pick={|pick: bool| *plain = pick}
+                            />
+                        }
+                    }
                 </View>
-            </View>
-            <Separator vertical/>
-            <Code
-                meta={*current}
-                plain={showing_plain}
-                on_pick={|pick: bool| *plain = pick}
-            />
+                // Not while the menu is down: it covers the corner the
+                // button floats in, and nothing behind it should be pressed.
+                if !open {
+                    <PaneToggle showing={showing} on_toggle={|next: Pane| *pane = next}/>
+                }
+                <Menu
+                    open={open}
+                    shown={&shown}
+                    active={&active}
+                    selected={current.name}
+                    on_select={|name: &'static str| {
+                        *selected = name;
+                        // A new example starts on its egui-react version.
+                        *plain = false;
+                        // Picked, so the menu has done its job.
+                        *menu_open = false;
+                    }}
+                    on_tag={|tag: &'static str| toggle(&mut tags, tag)}
+                    on_clear={|| tags.clear()}
+                    on_close={|| *menu_open = false}
+                />
+            } else {
+                <View direction="row" grow={1.0} min_h={0.0} gap={8}>
+                    // `shrink={0}` so the list keeps its width when the window
+                    // is narrow; the centre column is the one that gives way.
+                    <List
+                        w={200.0}
+                        shrink={0.0}
+                        shown={&shown}
+                        active={&active}
+                        selected={current.name}
+                        on_select={|name: &'static str| {
+                            *selected = name;
+                            // A new example starts on its egui-react version.
+                            *plain = false;
+                        }}
+                        on_tag={|tag: &'static str| toggle(&mut tags, tag)}
+                        on_clear={|| tags.clear()}
+                    />
+                    <Separator vertical/>
+                    // `min_w={0}` makes the centre the column that gives way:
+                    // taffy may otherwise take a flex item's content as its
+                    // automatic minimum, and a wide example would push the
+                    // code column off the right edge instead of being cut off
+                    // itself.
+                    <View direction="column" grow={1.0} min_w={0.0} gap={4}>
+                        // The summary, not the name: the name is already the
+                        // label of the list button and two widgets with one
+                        // label are ambiguous to a screen reader (and to
+                        // kittest).
+                        <Text strong>{current.summary}</Text>
+                        // The `key` is the whole point: change it and the
+                        // previous example's hooks are swept, so state does
+                        // not leak across.
+                        <View key={current.name} direction="column" grow={1.0}>
+                            <Running name={current.name} plain={showing_plain}/>
+                        </View>
+                    </View>
+                    <Separator vertical/>
+                    // A fixed share of the window, never squeezed by what the
+                    // running example wants: `shrink={0}` sends the whole
+                    // overflow to the centre column, which is the one with
+                    // `min_w={0}`.
+                    <Code
+                        w="40%"
+                        min_w={360.0}
+                        shrink={0.0}
+                        meta={*current}
+                        plain={showing_plain}
+                        on_pick={|pick: bool| *plain = pick}
+                    />
+                </View>
+            }
         </View>
     }
 }
 
+/// The page header: the title on the left and, on a compact screen, the menu
+/// button on the right.
+///
+/// A wide window has the list in a column of its own, so it has nothing for
+/// the button to open.
+#[component]
+fn Header(cx: &mut Cx, compact: bool, #[event] on_menu: ()) {
+    rsx! {
+        <View direction="row" align="center" gap={8} w="100%">
+            <Text strong size={20.0} grow={1.0}>"egui-react"</Text>
+            if compact {
+                <Button label="menu" on_click={|| on_menu.emit(())}>"☰"</Button>
+            }
+        </View>
+    }
+}
+
+/// The button floating in the bottom-right corner of a compact screen, which
+/// swaps the running example for its code and back.
+///
+/// An `egui::Area` rather than a node of the tree: it sits over the pane,
+/// where a thumb reaches, and takes no room from it. The label says what a
+/// press does; the glyph is what is drawn.
+#[component]
+fn PaneToggle(cx: &mut Cx, showing: Pane, #[event] on_toggle: Pane) {
+    let ctx = cx.ctx().clone();
+    let (glyph, label, next) = match showing {
+        Pane::Example => ("</>", "show code", Pane::Code),
+        Pane::Code => ("⏵", "show example", Pane::Example),
+    };
+    let clicked = egui::Area::new(cx.scope_id().with("pane_toggle"))
+        .order(egui::Order::Foreground)
+        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-16.0, -16.0))
+        .show(&ctx, |ui| {
+            egui::Frame::new()
+                .shadow(ui.visuals().window_shadow)
+                .corner_radius(24.0)
+                .show(ui, |ui| {
+                    ui.spacing_mut().button_padding = egui::vec2(16.0, 12.0);
+                    let button = egui::Button::new(egui::RichText::new(glyph).size(18.0))
+                        .corner_radius(24.0)
+                        .wrap_mode(egui::TextWrapMode::Extend);
+                    let response = ui.add(button);
+                    // The glyph is not a name; see `<Button label>`.
+                    ui.ctx()
+                        .accesskit_node_builder(response.id, |node| node.set_label(label));
+                    response.clicked()
+                })
+                .inner
+        })
+        .inner;
+    if clicked {
+        on_toggle.emit(next);
+    }
+}
+
+/// The menu of a compact screen: the example list and the tag filter, over
+/// the whole window.
+///
+/// It slides down from the top edge when it opens and back up when it closes,
+/// and it is not drawn at all once it is away. While it is on screen it is an
+/// `egui::Area` in the foreground that spans the window, so the pane beneath
+/// gets no clicks. Inside, the list is laid out by a tree of its own, rooted
+/// the way the runner roots the app, so it fills the sheet and the example
+/// list scrolls in what the header leaves.
+#[component]
+fn Menu(
+    cx: &mut Cx,
+    open: bool,
+    shown: &[&'static Meta],
+    active: &[&'static str],
+    selected: &'static str,
+    #[event] on_select: &'static str,
+    #[event] on_tag: &'static str,
+    #[event] on_clear: (),
+    #[event] on_close: (),
+) {
+    let (store, scope) = (cx.store, cx.scope_id());
+    let ctx = cx.ctx().clone();
+    // 0 when the menu is away, 1 when it is down; in between it is moving.
+    let down = ctx.animate_bool_with_time_and_easing(
+        scope.with("slide"),
+        open,
+        MENU_TIME,
+        egui::emath::easing::cubic_out,
+    );
+    if down <= 0.0 {
+        return;
+    }
+    let screen = ctx.content_rect();
+    let top = screen.top() - screen.height() * (1.0 - down);
+    let id = scope.with("menu");
+    // Above the pane toggle and anything else in the foreground, every frame:
+    // egui keeps the areas in the order they were first shown, and a click
+    // brings one to the front.
+    ctx.move_to_top(egui::LayerId::new(egui::Order::Foreground, id));
+    egui::Area::new(id)
+        .order(egui::Order::Foreground)
+        .fixed_pos(egui::pos2(screen.left(), top))
+        // Partly above the window while it slides.
+        .constrain(false)
+        .default_size(screen.size())
+        .show(&ctx, move |ui| {
+            let sheet = egui::Rect::from_min_size(ui.max_rect().min, screen.size());
+            ui.painter()
+                .rect_filled(sheet, 0.0, ui.visuals().panel_fill);
+            // The whole sheet, not just the widgets on it, is what stops a
+            // press from reaching the pane beneath.
+            ui.allocate_rect(sheet, egui::Sense::click());
+            let inner = sheet.shrink(8.0);
+            let mut ui = ui.new_child(egui::UiBuilder::new().max_rect(inner));
+            let mut cx = Cx::new(store, &mut ui, scope);
+            cx.root_container(scope.with("menu_root"), root_style(), |cx| {
+                rsx! {
+                    <View direction="column" gap={8} w="100%" h="100%">
+                        // The same header, with the button that closes the
+                        // menu where the one that opened it was.
+                        <View direction="row" align="center" gap={8} w="100%">
+                            <Text strong size={20.0} grow={1.0}>"egui-react"</Text>
+                            <Button label="close menu" on_click={|| on_close.emit(())}>"×"</Button>
+                        </View>
+                        <List
+                            w="100%"
+                            grow={1.0}
+                            min_h={0.0}
+                            shown={shown}
+                            active={active}
+                            selected={selected}
+                            on_select={|name: &'static str| on_select.emit(name)}
+                            on_tag={|tag: &'static str| on_tag.emit(tag)}
+                            on_clear={|| on_clear.emit(())}
+                        />
+                    </View>
+                }
+                .show(cx);
+            });
+        });
+}
+
 /// The example list and the tag filter.
+///
+/// The width is the caller's: a column of its own in the wide layout, the
+/// whole sheet in the menu.
 #[component]
 fn List(
     cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,
     shown: &[&'static Meta],
     active: &[&'static str],
     selected: &'static str,
@@ -133,9 +380,7 @@ fn List(
     #[event] on_clear: (),
 ) {
     rsx! {
-        // `shrink={0}` so the list keeps its width when the window is narrow;
-        // the centre column is the one that gives way.
-        <View direction="column" w={200.0} shrink={0.0} gap={6}>
+        <View style={style} direction="column" gap={6}>
             <Text strong size={18.0}>"examples"</Text>
             <ScrollArea grow={1.0}>
                 <View direction="column" gap={4} w="100%">
@@ -291,9 +536,18 @@ plain_example!(LayoutPlain, layout::plain);
 /// versions draw the same thing, and the numbers next to the buttons say what
 /// that costs in each.
 ///
+/// The width is the caller's, like [`List`]'s: 40% of the window in the wide
+/// layout, all of it in the compact one.
+///
 /// `pub` for `tests/bench.rs`, which times this column on its own.
 #[component]
-pub fn Code(cx: &mut Cx, meta: Meta, plain: bool, #[event] on_pick: bool) {
+pub fn Code(
+    cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,
+    meta: Meta,
+    plain: bool,
+    #[event] on_pick: bool,
+) {
     let file = if plain { "plain.rs" } else { "lib.rs" };
     let link = format!("{REPO}/{}/src/{file}", meta.name);
     // What is shown, and counted: the source minus the gallery's own plumbing.
@@ -313,10 +567,7 @@ pub fn Code(cx: &mut Cx, meta: Meta, plain: bool, #[event] on_pick: bool) {
     });
 
     rsx! {
-        // A fixed share of the window, never squeezed by what the running
-        // example wants: `shrink={0}` sends the whole overflow to the centre
-        // column, which is the one with `min_w={0}`.
-        <View direction="column" w="40%" min_w={360.0} shrink={0.0} gap={6}>
+        <View style={style} direction="column" gap={6}>
             if meta.plain.is_some() {
                 <View direction="row" gap={4} align="center" w="100%">
                     <Chip

--- a/examples/gallery/tests/bench.rs
+++ b/examples/gallery/tests/bench.rs
@@ -98,7 +98,14 @@ fn code_pane(meta: &'static Meta) -> f64 {
             <View direction="row" grow={1.0} gap={8}>
                 <View w={200.0} shrink={0.0}/>
                 <View grow={1.0} min_w={0.0}/>
-                <Code meta={*meta} plain={false} on_pick={|_: bool| {}}/>
+                <Code
+                    w="40%"
+                    min_w={360.0}
+                    shrink={0.0}
+                    meta={*meta}
+                    plain={false}
+                    on_pick={|_: bool| {}}
+                />
             </View>
         };
         view.show(cx);

--- a/examples/gallery/tests/gallery.rs
+++ b/examples/gallery/tests/gallery.rs
@@ -1,11 +1,11 @@
 //! Plan test A-4: picking an example from the list runs it, and a tag narrows
-//! the list.
+//! the list. And the compact layout: one pane, a floating toggle and a menu.
 
 use egui_kittest::Harness;
-use egui_kittest::kittest::Queryable as _;
+use egui_kittest::kittest::{NodeT as _, Queryable as _};
 use egui_react::prelude::*;
 use egui_react_app::{root_id, root_style};
-use gallery::{App, shown_source};
+use gallery::{App, COMPACT_WIDTH, shown_source};
 
 /// The runner's frame, minus eframe: one pass inside the real root container,
 /// so the gallery's three columns are sized the way they are under
@@ -30,6 +30,17 @@ const HEIGHT: f32 = 1000.0;
 fn harness<'a>() -> Harness<'a, Store> {
     Harness::builder()
         .with_size(egui::vec2(WIDTH, HEIGHT))
+        .build_ui_state(run_app, Store::new())
+}
+
+/// A phone in portrait: well under [`COMPACT_WIDTH`], so the gallery is one
+/// pane and a menu.
+const PHONE: egui::Vec2 = egui::vec2(390.0, 844.0);
+
+fn phone_harness<'a>() -> Harness<'a, Store> {
+    assert!(PHONE.x < COMPACT_WIDTH);
+    Harness::builder()
+        .with_size(PHONE)
         .build_ui_state(run_app, Store::new())
 }
 
@@ -173,9 +184,16 @@ fn the_toggle_follows_the_example() {
     assert!(fetch::META.plain.is_none());
 }
 
+/// Whether the version chip with this label is the one on.
+///
+/// The chips, not any node with the label: the page header is titled
+/// `egui-react` too, and a heading has no toggled state.
 fn toggled(harness: &Harness<'_, Store>, label: &str) -> bool {
-    use egui_kittest::kittest::NodeT as _;
-    harness.get_by_label(label).accesskit_node().toggled() == Some(egui::accesskit::Toggled::True)
+    let chip = harness
+        .get_all_by_label(label)
+        .find(|node| node.accesskit_node().toggled().is_some())
+        .unwrap_or_else(|| panic!("no chip labelled {label:?}"));
+    chip.accesskit_node().toggled() == Some(egui::accesskit::Toggled::True)
 }
 
 /// The code is one selectable label per line. A drag that starts on one line
@@ -204,9 +222,12 @@ fn a_drag_across_code_lines_copies_them() {
     harness.run_steps(3);
 
     // The pane is the right 40% of the window; a Monospace row is 15 points
-    // at this style, and the first one starts 36 points down.
+    // at this style, and the first one starts under the line-count row, past
+    // the column's 6-point gap.
+    let counted = format!("{} lines", shown_source(patch::META.source).lines().count());
+    let top = harness.get_by_label(&counted).rect().bottom() + 6.0;
     let x = WIDTH * 0.6 + 40.0;
-    let line = |i: f32| egui::pos2(x, 36.0 + 15.0 * i + 7.0);
+    let line = |i: f32| egui::pos2(x, top + 15.0 * i + 7.0);
 
     harness.hover_at(line(1.0));
     harness.step();
@@ -239,4 +260,143 @@ fn a_drag_across_code_lines_copies_them() {
     for line in &lines {
         assert!(shown.contains(line), "not from the shown source: {line:?}");
     }
+}
+
+/// On a phone there is one pane, and the floating button swaps it for the
+/// code and back. The list and the tags are behind the menu button, not on
+/// the page.
+#[test]
+fn a_phone_shows_one_pane_at_a_time() {
+    let mut harness = phone_harness();
+    harness.run();
+
+    // The header: the title and the menu button. The wide layout has no menu
+    // button, and this one has no list on the page.
+    assert!(harness.query_by_label("menu").is_some());
+    assert!(harness.query_by_label("examples").is_none());
+    assert!(harness.query_by_label("use_future").is_none());
+
+    // The example pane is up: showcase is running, and the code is not there.
+    assert!(harness.query_by_label("no notes").is_some());
+    assert!(harness.query_by_label("source on GitHub").is_none());
+
+    // The toggle floats in the bottom-right corner, inside the window.
+    let toggle = harness.get_by_label("show code").rect();
+    assert!(
+        toggle.right() <= PHONE.x && toggle.bottom() <= PHONE.y,
+        "{toggle:?}"
+    );
+    assert!(
+        toggle.left() > PHONE.x / 2.0 && toggle.top() > PHONE.y / 2.0,
+        "{toggle:?}"
+    );
+
+    harness.get_by_label("show code").click();
+    harness.run();
+    harness.run();
+
+    // The code pane, the full width of the window, and the example is gone
+    // with its hooks.
+    assert!(harness.query_by_label("no notes").is_none());
+    let link = harness.get_by_label("source on GitHub").rect();
+    assert!(
+        link.right() <= PHONE.x,
+        "the code pane ran off the right edge: {link:?}"
+    );
+    let counted = format!(
+        "{} lines",
+        shown_source(showcase::META.source).lines().count()
+    );
+    let counted = harness.get_by_label(&counted).rect();
+    assert!(
+        counted.left() < 40.0,
+        "the code pane is not at the left edge: {counted:?}"
+    );
+
+    harness.get_by_label("show example").click();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("no notes").is_some());
+    assert!(harness.query_by_label("source on GitHub").is_none());
+}
+
+/// The menu slides down over the page, lists every example and every tag,
+/// and closes again when an example is picked or its own button is pressed.
+#[test]
+fn the_menu_opens_over_a_phone_and_closes_on_a_pick() {
+    let mut harness = phone_harness();
+    harness.run();
+
+    harness.get_by_label("menu").click();
+    // One pass to apply the write, then the slide: `run` steps until nothing
+    // asks for a repaint, and the animation does until it is down.
+    harness.run();
+    harness.run();
+
+    // The list and the tags are on the sheet, and the sheet is the whole
+    // window: the toggle is under it, so it is not drawn.
+    assert!(harness.query_by_label("examples").is_some());
+    assert!(harness.query_by_label("use_future").is_some());
+    assert!(harness.query_by_label("show code").is_none());
+    let heading = harness.get_by_label("examples").rect();
+    assert!(heading.top() >= 0.0 && heading.top() < 100.0, "{heading:?}");
+
+    // A tag narrows the list without closing the menu.
+    harness.get_by_label("use_future").click();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("examples").is_some());
+    assert!(harness.query_by_label("patch").is_some());
+    assert!(harness.query_by_label("todo").is_none());
+    harness.get_by_label("clear").click();
+    harness.run();
+    harness.run();
+
+    // Picking an example runs it and takes the menu away.
+    harness.get_by_label("todo").click();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("0 left").is_some());
+    assert!(harness.query_by_label("examples").is_none());
+    assert!(harness.query_by_label("show code").is_some());
+
+    // So does the button on the sheet itself.
+    harness.get_by_label("menu").click();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("examples").is_some());
+    harness.get_by_label("close menu").click();
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("examples").is_none());
+    // And the example under it is still the one that was picked.
+    assert!(harness.query_by_label("0 left").is_some());
+}
+
+/// While the menu is down, a press lands on the sheet and not on the pane
+/// beneath it.
+#[test]
+fn the_menu_covers_the_pane() {
+    let mut harness = phone_harness();
+    harness.run();
+
+    // Where showcase's "new" button is with the menu away.
+    let new = harness.get_by_label("new").rect().center();
+
+    harness.get_by_label("menu").click();
+    harness.run();
+    harness.run();
+
+    // A press and a release where the button was.
+    harness.hover_at(new);
+    harness.step();
+    harness.drag_at(new);
+    harness.step();
+    harness.drop_at(new);
+    harness.run();
+    harness.run();
+    // No note was made: the menu is still down and the notebook is still
+    // empty behind it.
+    assert!(harness.query_by_label("examples").is_some());
+    assert!(harness.query_by_label("no notes").is_some());
 }

--- a/examples/gallery/tests/gallery.rs
+++ b/examples/gallery/tests/gallery.rs
@@ -36,9 +36,9 @@ fn harness<'a>() -> Harness<'a, Store> {
 /// A phone in portrait: well under [`COMPACT_WIDTH`], so the gallery is one
 /// pane and a menu.
 const PHONE: egui::Vec2 = egui::vec2(390.0, 844.0);
+const _: () = assert!(PHONE.x < COMPACT_WIDTH);
 
 fn phone_harness<'a>() -> Harness<'a, Store> {
-    assert!(PHONE.x < COMPACT_WIDTH);
     Harness::builder()
         .with_size(PHONE)
         .build_ui_state(run_app, Store::new())


### PR DESCRIPTION
Below 720 points of width the gallery is one pane rather than three
columns: the running example or its code, swapped by a button floating
in the bottom-right corner. A page header carries the title on the left
and, on a compact screen, a menu button on the right; the menu holds the
example list and the tag filter, covers the whole window and slides down
from the top edge (and back up) when toggled.

The wide layout keeps its three columns under the same header. `List`
and `Code` take their width from the caller now, so both layouts share
them.

Tests cover the compact layout: one pane at a time, the floating toggle,
the menu opening over the page, closing on a pick, and swallowing the
presses meant for the pane beneath.