### PR TITLE
feat: overlays without the escape hatch (Overlay, use_animate, display="none")

### DIFF
--- a/crates/egui-react-app/src/lib.rs
+++ b/crates/egui-react-app/src/lib.rs
@@ -5,7 +5,6 @@
 //! `use_persisted` to eframe's storage, and absorbs the difference between
 //! native and wasm.
 
-use egui_react::layout::{ContainerStyle, ItemStyle};
 use egui_react::{Cx, Store, View};
 
 pub mod a11y;
@@ -23,35 +22,10 @@ pub fn root_id() -> egui::Id {
     egui::Id::new(ROOT_ID)
 }
 
-/// The taffy style of the root container: a column that fills the window.
+/// The taffy style of the root container, as [`egui_react::layout::root_style`].
 ///
-/// `reserve_available_space` tells the layout engine how much room there is,
-/// but it leaves the root node's own `size` at `auto`, so taffy would size that
-/// node by its content. Two things go wrong then. A `<View grow={1.0}
-/// justify="center">` child finds no free space to grow into and nothing to be
-/// centred in, so the app sits in the window's top-left corner. And a child
-/// too wide to fit never has to shrink, because a content-sized parent simply
-/// grows with it and there is no overflow to resolve — the row runs off the
-/// right edge instead of `grow` and `flex-shrink` sharing out what there is.
-///
-/// So both sides are fixed at 100%: a window is exactly as big as it is. The
-/// height used to be only a *minimum* of 100%, so that a column taller than
-/// the window would lay out at its own height. That let a `leaf_fill` (a
-/// `<ScrollArea>`, a `<VirtualList>`) push the root past the window: such a
-/// leaf reports the whole root height as its content size, so a column of
-/// "a header, then a list that fills the rest" measured as header plus window,
-/// and the root grew to fit — the list's last rows sat below the window edge.
-/// With a definite height the header keeps its content height (a flex item's
-/// automatic minimum) and the list gets what is left. Content taller than the
-/// window still overflows it rather than being shrunk, for the same reason,
-/// and belongs in a `ScrollArea` as it always did.
-///
-/// Exposed for the same reason as [`root_id`].
-pub fn root_style() -> egui_react::taffy::Style {
-    ContainerStyle::default()
-        .direction("column")
-        .merge(&ItemStyle::default().w("100%").h("100%"))
-}
+/// Re-exported here so a hand-written runner needs one import.
+pub use egui_react::layout::root_style;
 
 /// What [`Options::setup`] holds: run once, when eframe is ready.
 pub type Setup = Box<dyn FnOnce(&eframe::CreationContext<'_>)>;

--- a/crates/egui-react-elements/src/containers.rs
+++ b/crates/egui-react-elements/src/containers.rs
@@ -212,6 +212,12 @@ pub fn Overlay(
     fill: Option<egui::Color32>,
     children: impl View,
 ) {
+    // An `Area` is a layer of its own, so an invisible leaf `Ui` never reaches
+    // it: a hidden one is not drawn at all, and its children unmount as when
+    // `open` is false.
+    if cx.is_hidden() {
+        return;
+    }
     let (store, scope) = (cx.store, cx.scope_id());
     let layout = cx.layout_id();
     let ctx = cx.ctx().clone();
@@ -403,6 +409,12 @@ pub fn Window(
     default_size: Option<egui::Vec2>,
     children: impl View,
 ) {
+    // An `Area` is a layer of its own, so an invisible leaf `Ui` never reaches
+    // it: a hidden one is not drawn at all, and its children unmount as when
+    // `open` is false.
+    if cx.is_hidden() {
+        return;
+    }
     let (store, scope) = (cx.store, cx.scope_id());
     let layout = cx.layout_id();
     let ctx = cx.ctx().clone();
@@ -448,6 +460,12 @@ pub fn Panel(
     #[prop(default = true)] resizable: bool,
     children: impl View,
 ) {
+    // A docked panel draws into the tree's root `Ui`, not into the invisible
+    // leaf `Ui` of a hidden view, so a hidden one is not drawn at all; its
+    // children unmount as when a `<Window>` is closed.
+    if cx.is_hidden() {
+        return;
+    }
     let (store, scope) = (cx.store, cx.scope_id());
     let layout = cx.layout_id();
     let show = move |ui: &mut egui::Ui| {
@@ -482,6 +500,12 @@ pub fn Panel(
 /// Docks in the same `Ui` as [`Panel`], for the same reasons.
 #[component(shares_ui)]
 pub fn CentralPanel(cx: &mut Cx, #[prop(default)] style: ItemStyle, children: impl View) {
+    // A docked panel draws into the tree's root `Ui`, not into the invisible
+    // leaf `Ui` of a hidden view, so a hidden one is not drawn at all; its
+    // children unmount as when a `<Window>` is closed.
+    if cx.is_hidden() {
+        return;
+    }
     let (store, scope) = (cx.store, cx.scope_id());
     let layout = cx.layout_id();
     let show = move |ui: &mut egui::Ui| {

--- a/crates/egui-react-elements/src/containers.rs
+++ b/crates/egui-react-elements/src/containers.rs
@@ -106,7 +106,11 @@ pub fn Collapsing(
 }
 
 /// A painted frame: background, border and inner margin.
+///
+/// `shadow` casts the theme's window shadow; `custom_shadow` casts one of the
+/// caller's own instead, and wins over `shadow`.
 #[component]
+#[allow(clippy::too_many_arguments)]
 pub fn Frame(
     cx: &mut Cx,
     #[prop(default)] style: ItemStyle,
@@ -114,6 +118,8 @@ pub fn Frame(
     stroke: Option<egui::Stroke>,
     inner_margin: Option<f32>,
     corner_radius: Option<f32>,
+    #[prop(default)] shadow: bool,
+    custom_shadow: Option<egui::Shadow>,
     children: impl View,
 ) {
     let (store, scope) = (cx.store, cx.scope_id());
@@ -131,6 +137,11 @@ pub fn Frame(
         }
         if let Some(radius) = corner_radius {
             frame = frame.corner_radius(radius as u8);
+        }
+        if let Some(shadow) = custom_shadow {
+            frame = frame.shadow(shadow);
+        } else if shadow {
+            frame = frame.shadow(ui.visuals().window_shadow);
         }
         frame.show(ui, move |ui| {
             let mut cx = Cx::new(store, ui, scope);

--- a/crates/egui-react-elements/src/containers.rs
+++ b/crates/egui-react-elements/src/containers.rs
@@ -9,7 +9,7 @@
 //! the slot's id, and a `<View>` under one of these containers has to key its
 //! taffy tree by the slot like any other, not by the row index in `scope`.
 
-use egui_react::layout::ItemStyle;
+use egui_react::layout::{ItemStyle, Length, root_style};
 use egui_react::prelude::*;
 
 /// Which edge a [`Panel`] is docked to.
@@ -47,6 +47,239 @@ impl From<&str> for Side {
             panic!("egui-react: {s:?} is not a valid Side (expected left, right, top or bottom)")
         })
     }
+}
+
+/// Where an [`Overlay`] is pinned to the window.
+///
+/// Both spellings are accepted: the CSS-ish one (`"bottom-right"`, `"top"`,
+/// `"center"`) and egui's `Align2` order (`"right-bottom"`, `"center-top"`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Anchor {
+    /// The top-left corner.
+    #[default]
+    TopLeft,
+    /// The middle of the top edge.
+    Top,
+    /// The top-right corner.
+    TopRight,
+    /// The middle of the left edge.
+    Left,
+    /// The middle of the window.
+    Center,
+    /// The middle of the right edge.
+    Right,
+    /// The bottom-left corner.
+    BottomLeft,
+    /// The middle of the bottom edge.
+    Bottom,
+    /// The bottom-right corner.
+    BottomRight,
+}
+
+impl Anchor {
+    /// Parse either spelling, returning `None` if unknown.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "top-left" | "left-top" => Some(Self::TopLeft),
+            "top" | "center-top" => Some(Self::Top),
+            "top-right" | "right-top" => Some(Self::TopRight),
+            "left" | "left-center" => Some(Self::Left),
+            "center" | "center-center" => Some(Self::Center),
+            "right" | "right-center" => Some(Self::Right),
+            "bottom-left" | "left-bottom" => Some(Self::BottomLeft),
+            "bottom" | "center-bottom" => Some(Self::Bottom),
+            "bottom-right" | "right-bottom" => Some(Self::BottomRight),
+            _ => None,
+        }
+    }
+
+    /// The egui alignment this anchor pins to.
+    pub fn to_align2(self) -> egui::Align2 {
+        match self {
+            Self::TopLeft => egui::Align2::LEFT_TOP,
+            Self::Top => egui::Align2::CENTER_TOP,
+            Self::TopRight => egui::Align2::RIGHT_TOP,
+            Self::Left => egui::Align2::LEFT_CENTER,
+            Self::Center => egui::Align2::CENTER_CENTER,
+            Self::Right => egui::Align2::RIGHT_CENTER,
+            Self::BottomLeft => egui::Align2::LEFT_BOTTOM,
+            Self::Bottom => egui::Align2::CENTER_BOTTOM,
+            Self::BottomRight => egui::Align2::RIGHT_BOTTOM,
+        }
+    }
+}
+
+impl From<&str> for Anchor {
+    /// # Panics
+    /// Panics on an unknown spelling.
+    fn from(s: &str) -> Self {
+        Self::parse(s).unwrap_or_else(|| {
+            panic!(
+                "egui-react: {s:?} is not a valid Anchor (expected top-left, top, top-right, \
+                 left, center, right, bottom-left, bottom or bottom-right)"
+            )
+        })
+    }
+}
+
+/// Which layer an [`Overlay`] is drawn in: [`egui::Order`], with `From<&str>`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Order {
+    /// Behind everything else.
+    Background,
+    /// Above the background, below the windows.
+    Middle,
+    /// Above the windows. The default.
+    #[default]
+    Foreground,
+    /// Above everything, where tooltips live.
+    Tooltip,
+}
+
+impl Order {
+    /// Parse the CSS-ish spelling, returning `None` if unknown.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "background" => Some(Self::Background),
+            "middle" => Some(Self::Middle),
+            "foreground" => Some(Self::Foreground),
+            "tooltip" => Some(Self::Tooltip),
+            _ => None,
+        }
+    }
+
+    /// The egui order this one names.
+    pub fn to_egui(self) -> egui::Order {
+        match self {
+            Self::Background => egui::Order::Background,
+            Self::Middle => egui::Order::Middle,
+            Self::Foreground => egui::Order::Foreground,
+            Self::Tooltip => egui::Order::Tooltip,
+        }
+    }
+}
+
+impl From<&str> for Order {
+    /// # Panics
+    /// Panics on an unknown spelling.
+    fn from(s: &str) -> Self {
+        Self::parse(s).unwrap_or_else(|| {
+            panic!(
+                "egui-react: {s:?} is not a valid Order (expected background, middle, foreground \
+                 or tooltip)"
+            )
+        })
+    }
+}
+
+/// A floating layer over the app: a sheet, a menu, a corner button.
+///
+/// Like a `<Window>` it is drawn in a layer of its own, so it takes no space
+/// in the surrounding layout and can sit over anything. It has two modes.
+///
+/// **Sized** (`w` and/or `h` given): the size is known before anything is
+/// drawn, so the overlay paints a sheet, takes the presses that land on it,
+/// and roots a taffy tree of its own — a `<View>` inside is laid out against
+/// the sheet, as the app root is against the window. A press on the sheet goes
+/// nowhere: it never reaches the widgets underneath. The sheet is filled with
+/// `fill`, or with the theme's `panel_fill`; `fill={egui::Color32::TRANSPARENT}`
+/// opts out. A `Percent` length is a fraction of the window
+/// (`egui::Context::content_rect`), and an axis that is not given is the
+/// window's whole length on that axis.
+///
+/// **Unsized** (neither given): the overlay is as big as its children, paints
+/// nothing unless `fill` is given, and lets every press it does not want
+/// through. Put a `<View w=..>` inside to lay the children out.
+///
+/// `pos` places the overlay by hand and wins over `anchor`; with neither, egui
+/// opens it in the top-left corner. `offset` moves an anchored overlay off its
+/// corner (negative to come back in from the right or the bottom). `constrain`
+/// (on by default) keeps it inside the window. `top` lifts it above the other
+/// overlays every frame, which is what beats egui's own rule that the area
+/// shown later is on top. Not drawing an `<Overlay>` unmounts its children,
+/// as `open={false}` does for a `<Window>`.
+#[component]
+#[allow(clippy::too_many_arguments)]
+pub fn Overlay(
+    cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,
+    #[prop(into)] anchor: Option<Anchor>,
+    #[prop(default)] offset: (f32, f32),
+    pos: Option<egui::Pos2>,
+    #[prop(default, into)] order: Order,
+    #[prop(default = true)] constrain: bool,
+    #[prop(default)] top: bool,
+    fill: Option<egui::Color32>,
+    children: impl View,
+) {
+    let (store, scope) = (cx.store, cx.scope_id());
+    let layout = cx.layout_id();
+    let ctx = cx.ctx().clone();
+    let screen = ctx.content_rect();
+
+    // Sized: the sheet is known before anything is drawn, so it can take the
+    // presses and root a tree. `Px` as is, `Percent` of the window, an axis
+    // that is not given is the window's.
+    let sized = style.w.is_some() || style.h.is_some();
+    let resolve = |len: Option<Length>, full: f32| match len {
+        Some(Length::Px(v)) => v,
+        Some(Length::Percent(p)) => p * full,
+        Some(Length::Auto) | None => full,
+    };
+    let sheet_size = egui::vec2(
+        resolve(style.w, screen.width()),
+        resolve(style.h, screen.height()),
+    );
+
+    let mut area = egui::Area::new(scope)
+        .order(order.to_egui())
+        .constrain(constrain)
+        // `Area::new` is movable by default; `anchor` / `fixed_pos` clear it,
+        // a bare overlay has to.
+        .movable(false);
+    match (pos, anchor) {
+        (Some(pos), _) => area = area.fixed_pos(pos),
+        (None, Some(anchor)) => {
+            area = area.anchor(anchor.to_align2(), egui::vec2(offset.0, offset.1));
+        }
+        (None, None) => {}
+    }
+    if sized {
+        // Right on the first frame, before the sheet has been allocated once.
+        area = area.default_size(sheet_size);
+    }
+    if top {
+        // Every frame: egui keeps the areas of an `Order` in first-shown
+        // order and a click brings one forward.
+        ctx.move_to_top(area.layer());
+    }
+    area.show(&ctx, move |ui| {
+        if sized {
+            let sheet = egui::Rect::from_min_size(ui.max_rect().min, sheet_size);
+            let fill = fill.unwrap_or_else(|| ui.visuals().panel_fill);
+            ui.painter().rect_filled(sheet, 0.0, fill);
+            // The whole sheet, before the children: it makes the area the
+            // sheet's size (that is what stops a press reaching the layer
+            // beneath) and a later widget in the same layer is on top of it,
+            // so the children's buttons still get theirs.
+            ui.allocate_rect(sheet, egui::Sense::click());
+            let mut ui = ui.new_child(egui::UiBuilder::new().max_rect(sheet));
+            let mut cx = Cx::new(store, &mut ui, scope);
+            cx.with_layout_id(layout, |cx| {
+                cx.root_container(scope.with("overlay"), root_style(), |cx| children.show(cx));
+            });
+        } else {
+            // The background is painted after the children, into a slot
+            // claimed before them, because the area's rect is what they drew.
+            let background = fill.map(|_| ui.painter().add(egui::Shape::Noop));
+            let mut cx = Cx::new(store, ui, scope);
+            cx.with_layout_id(layout, |cx| children.show(cx));
+            if let (Some(idx), Some(fill)) = (background, fill) {
+                ui.painter()
+                    .set(idx, egui::Shape::rect_filled(ui.min_rect(), 0.0, fill));
+            }
+        }
+    });
 }
 
 /// A scrollable region.

--- a/crates/egui-react-elements/src/lib.rs
+++ b/crates/egui-react-elements/src/lib.rs
@@ -33,8 +33,8 @@ pub mod widgets;
 pub mod prelude {
     pub use crate::canvas::{Canvas, CanvasEvent};
     pub use crate::containers::{
-        CentralPanel, Collapsing, Frame, Grid, Horizontal, Panel, Row, ScrollArea, Side, Vertical,
-        Window,
+        Anchor, CentralPanel, Collapsing, Frame, Grid, Horizontal, Order, Overlay, Panel, Row,
+        ScrollArea, Side, Vertical, Window,
     };
     pub use crate::suspense::Suspense;
     pub use crate::view::{Text, View};

--- a/crates/egui-react-elements/src/widgets.rs
+++ b/crates/egui-react-elements/src/widgets.rs
@@ -20,16 +20,28 @@ use egui_react::prelude::*;
 /// `"x"` reads as that glyph and nothing more. It only renames the accessibility
 /// node; what is drawn stays the children.
 #[component]
+#[allow(clippy::too_many_arguments)]
 pub fn Button(
     cx: &mut Cx,
     #[prop(default)] style: ItemStyle,
     #[prop(default = true)] enabled: bool,
     label: Option<&str>,
+    padding: Option<(f32, f32)>,
+    corner_radius: Option<f32>,
     #[event] on_click: (),
     children: impl Into<egui::WidgetText>,
 ) {
     let clicked = cx.leaf(&style, |ui| {
-        let button = egui::Button::new(children).wrap_mode(egui::TextWrapMode::Extend);
+        if let Some((x, y)) = padding {
+            // The leaf's own `Ui` in a tree, the scope's `push_id` child
+            // outside: `spacing_mut` copies the style, so nothing leaks past
+            // this element.
+            ui.spacing_mut().button_padding = egui::vec2(x, y);
+        }
+        let mut button = egui::Button::new(children).wrap_mode(egui::TextWrapMode::Extend);
+        if let Some(radius) = corner_radius {
+            button = button.corner_radius(radius); // `CornerRadius: From<f32>`
+        }
         let response = ui.add_enabled(enabled, button);
         if let Some(label) = label {
             // The widget has already written its node for this pass, so this

--- a/crates/egui-react-elements/tests/containers.rs
+++ b/crates/egui-react-elements/tests/containers.rs
@@ -311,3 +311,53 @@ fn a_panel_inside_a_view_docks_in_the_window() {
         "the panel and the rest must not overlap: {panel:?} {rest:?}",
     );
 }
+
+#[test]
+fn a_shadowed_frame_lays_out_like_a_plain_one() {
+    let mut harness = Harness::new_ui_state(
+        |ui, store: &mut Store| {
+            run_app(ui, store, |cx| {
+                rsx! {
+                    <View direction="column">
+                        <Frame inner_margin={4.0}>
+                            <Label>"framed"</Label>
+                        </Frame>
+                        <Frame shadow inner_margin={4.0}>
+                            <Label>"framed"</Label>
+                        </Frame>
+                        <Frame custom_shadow={egui::Shadow::NONE} inner_margin={4.0}>
+                            <Counter name="custom"/>
+                        </Frame>
+                    </View>
+                }
+                .show(cx);
+            });
+        },
+        Store::new(),
+    );
+
+    harness.run();
+    // The same text in both frames, so only the frames can move it: the labels
+    // come back in tree order, the plain one first.
+    let labels: Vec<_> = harness
+        .get_all_by_label("framed")
+        .map(|node| node.rect())
+        .collect();
+    assert_eq!(labels.len(), 2, "both frames should draw their label");
+    let (plain, shadowed) = (labels[0], labels[1]);
+
+    // A shadow is painted, not laid out: the two labels are the same size, at
+    // the same left edge, one under the other.
+    assert_eq!(plain.size(), shadowed.size(), "{plain:?} {shadowed:?}");
+    assert_eq!(plain.left(), shadowed.left(), "{plain:?} {shadowed:?}");
+    assert!(
+        plain.bottom() <= shadowed.top(),
+        "the frames should stack: {plain:?} {shadowed:?}",
+    );
+
+    // And the third frame's children keep their state.
+    assert!(harness.query_by_label("custom: 0").is_some());
+    harness.get_by_label("custom +").click();
+    harness.run();
+    assert!(harness.query_by_label("custom: 1").is_some());
+}

--- a/crates/egui-react-elements/tests/overlay.rs
+++ b/crates/egui-react-elements/tests/overlay.rs
@@ -1,0 +1,201 @@
+//! Plan 9.4: `<Overlay>` floats in a layer of its own — anchored in a corner,
+//! or a sized sheet that paints, takes the presses and roots a taffy tree.
+//!
+//! An area's first frame is egui's own sizing pass: invisible and not
+//! interactable. So every test runs the harness before it reads a rect or
+//! presses anything.
+
+mod common;
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use common::run_app;
+use egui_kittest::Harness;
+use egui_kittest::kittest::Queryable as _;
+use egui_react::prelude::*;
+use egui_react_elements::prelude::*;
+
+/// The window every test draws into.
+const SIZE: egui::Vec2 = egui::vec2(400.0, 800.0);
+
+/// A counter, so an overlay's children can be checked for their own state.
+#[component]
+fn Counter(cx: &mut Cx, name: &str) {
+    let mut count = use_state(cx, || 0i32);
+    cx.ui().label(format!("{name}: {}", *count));
+    if cx.ui().button(format!("{name} +")).clicked() {
+        *count += 1;
+    }
+}
+
+/// A 400x800 harness drawing `app`, run once so the areas are past their
+/// sizing pass.
+fn harness_for(app: impl Fn(&mut Cx<'_, '_>) + 'static) -> Harness<'static, Store> {
+    let mut harness = Harness::builder().with_size(SIZE).build_ui_state(
+        move |ui, store: &mut Store| {
+            run_app(ui, store, |cx| app(cx));
+        },
+        Store::new(),
+    );
+    harness.run();
+    harness
+}
+
+#[test]
+fn anchored_bottom_right_stays_in_the_corner() {
+    let harness = harness_for(|cx| {
+        rsx! {
+            <View direction="column" w="100%">
+                <Label>"behind"</Label>
+                <View h={2000.0}/>
+            </View>
+            <Overlay anchor="bottom-right" offset={(-16.0, -16.0)}>
+                <Button label="fab">"+"</Button>
+            </Overlay>
+        }
+        .show(cx);
+    });
+
+    let fab = harness.get_by_label("fab").rect();
+    assert!(
+        fab.right() <= SIZE.x - 15.0,
+        "not at the right edge: {fab:?}"
+    );
+    assert!(
+        fab.bottom() <= SIZE.y - 15.0,
+        "not at the bottom edge: {fab:?}"
+    );
+    // And in the corner, not merely inside the window.
+    assert!(fab.left() > 200.0, "too far left: {fab:?}");
+    assert!(fab.top() > 400.0, "too far up: {fab:?}");
+}
+
+#[test]
+fn a_sized_overlay_takes_the_presses() {
+    // A sheet over the whole window: the button under it never hears a press.
+    let clicks = Rc::new(Cell::new(0u32));
+    let counted = Rc::clone(&clicks);
+    let mut covered = harness_for(move |cx| {
+        let clicks = Rc::clone(&counted);
+        rsx! {
+            <Button label="under" on_click={|| clicks.set(clicks.get() + 1)}>"under"</Button>
+            <Overlay w="100%" h="100%">
+                <Label>"sheet"</Label>
+            </Overlay>
+        }
+        .show(cx);
+    });
+
+    // kittest presses at the node's centre, where the sheet's layer is on top.
+    covered.get_by_label("under").click();
+    covered.run();
+    assert_eq!(clicks.get(), 0, "the sheet let a press through");
+
+    // The same app without the sheet: the press lands.
+    let clicks = Rc::new(Cell::new(0u32));
+    let counted = Rc::clone(&clicks);
+    let mut bare = harness_for(move |cx| {
+        let clicks = Rc::clone(&counted);
+        rsx! {
+            <Button label="under" on_click={|| clicks.set(clicks.get() + 1)}>"under"</Button>
+        }
+        .show(cx);
+    });
+
+    bare.get_by_label("under").click();
+    bare.run();
+    assert_eq!(clicks.get(), 1, "the bare button should be clickable");
+}
+
+#[test]
+fn a_sized_overlay_roots_a_tree_that_fills_the_sheet() {
+    let harness = harness_for(|cx| {
+        rsx! {
+            <Overlay w="100%" h="100%">
+                <View direction="column" w="100%" h="100%" justify="space-between">
+                    <Label>"head"</Label>
+                    <Label>"foot"</Label>
+                </View>
+            </Overlay>
+        }
+        .show(cx);
+    });
+
+    let head = harness.get_by_label("head").rect();
+    let foot = harness.get_by_label("foot").rect();
+    assert!(head.top() < 30.0, "the head is not at the top: {head:?}");
+    assert!(
+        foot.bottom() > SIZE.y - 30.0,
+        "the foot is not at the bottom: {foot:?}"
+    );
+}
+
+#[test]
+fn an_overlay_not_drawn_unmounts_its_children() {
+    let show = Rc::new(Cell::new(true));
+    let shown = Rc::clone(&show);
+    let mut harness = harness_for(move |cx| {
+        let show = shown.get();
+        rsx! {
+            if show {
+                <Overlay anchor="center">
+                    <Counter name="sheet"/>
+                </Overlay>
+            }
+        }
+        .show(cx);
+    });
+
+    assert!(harness.query_by_label("sheet: 0").is_some());
+    harness.get_by_label("sheet +").click();
+    harness.run();
+    assert!(harness.query_by_label("sheet: 1").is_some());
+    assert_eq!(harness.state().len(), 1, "one slot: the counter's state");
+
+    // Not drawing the overlay unmounts the children through the usual sweep.
+    show.set(false);
+    harness.run();
+    assert!(harness.query_by_label("sheet: 1").is_none());
+    assert_eq!(harness.state().len(), 0, "the counter should be swept");
+
+    // And it comes back fresh.
+    show.set(true);
+    harness.run();
+    assert!(harness.query_by_label("sheet: 0").is_some());
+}
+
+#[test]
+fn top_keeps_an_overlay_above_a_later_one() {
+    /// Two overlays at the same place, each with a button of its own; the one
+    /// that hears the press writes its name.
+    fn stack(top: bool, pressed: &Rc<Cell<&'static str>>) -> Harness<'static, Store> {
+        let pressed = Rc::clone(pressed);
+        harness_for(move |cx| {
+            let (first, second) = (Rc::clone(&pressed), Rc::clone(&pressed));
+            rsx! {
+                <Overlay pos={egui::pos2(50.0, 50.0)} w={200.0} h={200.0} top={top}>
+                    <Button label="first" on_click={|| first.set("first")}>"first"</Button>
+                </Overlay>
+                <Overlay pos={egui::pos2(50.0, 50.0)} w={200.0} h={200.0}>
+                    <Button label="second" on_click={|| second.set("second")}>"second"</Button>
+                </Overlay>
+            }
+            .show(cx);
+        })
+    }
+
+    // `top` puts the first overlay back on top every frame.
+    let pressed = Rc::new(Cell::new("none"));
+    let mut harness = stack(true, &pressed);
+    harness.get_by_label("first").click();
+    harness.run();
+    assert_eq!(pressed.get(), "first");
+
+    // Without it, egui's own rule wins: the area shown later is above.
+    let pressed = Rc::new(Cell::new("none"));
+    let mut harness = stack(false, &pressed);
+    harness.get_by_label("first").click();
+    harness.run();
+    assert_eq!(pressed.get(), "second");
+}

--- a/crates/egui-react-elements/tests/widgets.rs
+++ b/crates/egui-react-elements/tests/widgets.rs
@@ -443,3 +443,52 @@ fn an_explicit_row_count_wins() {
         .rect();
     assert!(rect.height() < 80.0, "two rows should be short: {rect:?}",);
 }
+
+#[test]
+fn padding_widens_the_button() {
+    let clicks = Rc::new(std::cell::Cell::new(0u32));
+    let clicks_in_app = Rc::clone(&clicks);
+
+    let mut harness = Harness::new_ui_state(
+        move |ui, store: &mut Store| {
+            let clicks = Rc::clone(&clicks_in_app);
+            run_app(ui, store, move |cx| {
+                rsx! {
+                    <View direction="column">
+                        <Button label="plain">"x"</Button>
+                        <Button label="padded" padding={(16.0, 12.0)}>"x"</Button>
+                        <Button
+                            label="round"
+                            corner_radius={24.0}
+                            on_click={|| clicks.set(clicks.get() + 1)}
+                        >"x"</Button>
+                    </View>
+                }
+                .show(cx);
+            });
+        },
+        Store::new(),
+    );
+
+    harness.run();
+    let base = harness.ctx.global_style().spacing.button_padding;
+    let plain = harness.get_by_label("plain").rect();
+    let padded = harness.get_by_label("padded").rect();
+
+    // The leaf measure is `ceil`ed, so allow a point either way.
+    let wider = padded.width() - plain.width();
+    let taller = padded.height() - plain.height();
+    assert!(
+        (wider - 2.0 * (16.0 - base.x)).abs() <= 1.0,
+        "padding did not widen the button: {plain:?} {padded:?}",
+    );
+    assert!(
+        (taller - 2.0 * (12.0 - base.y)).abs() <= 1.0,
+        "padding did not heighten the button: {plain:?} {padded:?}",
+    );
+
+    // A rounded button is still a button.
+    harness.get_by_label("round").click();
+    harness.run();
+    assert_eq!(clicks.get(), 1);
+}

--- a/crates/egui-react/src/cx.rs
+++ b/crates/egui-react/src/cx.rs
@@ -139,6 +139,19 @@ impl<'s, 'u> Cx<'s, 'u> {
         matches!(self.surface, Surface::Tree(_) | Surface::Lite(_))
     }
 
+    /// Is this `Cx` inside a `display="none"` subtree?
+    ///
+    /// True inside a hidden `<View>` on either layout path, and inside anything
+    /// a leaf of one opens (a `<ScrollArea>`'s children, a tree of their own).
+    pub fn is_hidden(&self) -> bool {
+        self.store.in_hidden()
+            || match &self.surface {
+                Surface::Ui(_) => false,
+                Surface::Tree(tree) => tree.hidden(),
+                Surface::Lite(lite) => lite.hidden(),
+            }
+    }
+
     /// The id of the current component scope; the base of every hook id.
     pub fn scope_id(&self) -> egui::Id {
         self.scope
@@ -336,6 +349,9 @@ impl<'s, 'u> Cx<'s, 'u> {
     /// apply flex item properties to.
     pub fn leaf<R>(&mut self, style: &ItemStyle, f: impl FnOnce(&mut egui::Ui) -> R) -> R {
         let (prefix, scope) = (self.layout, self.scope);
+        // Held while the widget draws, so a tree it opens over its own `Ui`
+        // starts hidden as well.
+        let _hidden = self.is_hidden().then(|| self.store.enter_hidden());
         match &mut self.surface {
             Surface::Ui(ui) => f(ui),
             Surface::Tree(tree) => tree.leaf(prefix, scope, style.to_taffy(), true, f),
@@ -367,8 +383,17 @@ impl<'s, 'u> Cx<'s, 'u> {
         selectable: Option<bool>,
     ) -> egui::Response {
         let (prefix, scope) = (self.layout, self.scope);
+        let hidden = self.is_hidden();
         match &mut self.surface {
             Surface::Ui(ui) => {
+                if hidden {
+                    // Inside a hidden leaf: no `Label`, so no galley, no shape
+                    // and no accesskit node. The auto id is stepped over all
+                    // the same, so the widgets after this one keep their ids.
+                    let id = ui.next_auto_id();
+                    ui.skip_ahead_auto_ids(1);
+                    return ui.interact(egui::Rect::NOTHING, id, egui::Sense::hover());
+                }
                 let wrap_mode = if wrap {
                     egui::TextWrapMode::Wrap
                 } else {
@@ -398,6 +423,7 @@ impl<'s, 'u> Cx<'s, 'u> {
     /// or the remaining space in the container.
     pub fn leaf_fill<R>(&mut self, style: &ItemStyle, f: impl FnOnce(&mut egui::Ui) -> R) -> R {
         let (prefix, scope) = (self.layout, self.scope);
+        let _hidden = self.is_hidden().then(|| self.store.enter_hidden());
         match &mut self.surface {
             Surface::Ui(ui) => f(ui),
             Surface::Tree(tree) => tree.leaf(prefix, scope, style.to_taffy(), false, f),
@@ -435,7 +461,8 @@ impl<'s, 'u> Cx<'s, 'u> {
         {
             let tree = store.lite_tree(id);
             if lite::supported(&tree, container, item) {
-                return lite::show(&tree, ui, container, item, size, |lite| {
+                let hidden = store.in_hidden();
+                return lite::show(&tree, ui, container, item, size, hidden, |lite| {
                     let mut cx = Cx::at_lite(store, lite.reborrow(), scope, layout);
                     f(&mut cx)
                 });

--- a/crates/egui-react/src/engine/lite.rs
+++ b/crates/egui-react/src/engine/lite.rs
@@ -1840,6 +1840,9 @@ pub(crate) struct LiteCx<'u> {
     root_min: Pos2,
     /// The node children are added to.
     parent: usize,
+    /// Is this position inside a `display="none"` subtree? Same meaning and
+    /// same three consequences as on the taffy path.
+    hidden: bool,
     /// How many children have been added under `parent` so far. Only the `Ui`
     /// ids are salted with it, so that a leaf keeps the id it has on the taffy
     /// path.
@@ -1854,8 +1857,14 @@ impl LiteCx<'_> {
             root_ui: self.root_ui,
             root_min: self.root_min,
             parent: self.parent,
+            hidden: self.hidden,
             child_index: self.child_index,
         }
+    }
+
+    /// Is this position inside a `display="none"` subtree?
+    pub(crate) fn hidden(&self) -> bool {
+        self.hidden
     }
 
     /// The row's own `Ui`, which is what `cx.ui()` returns here.
@@ -1902,6 +1911,10 @@ impl LiteCx<'_> {
     ) -> R {
         self.check(Some(container), item);
         self.next_index();
+        // The node is pushed and `f` still runs, as on the taffy path: the
+        // components inside keep their hooks and the solver zeroes the
+        // subtree.
+        let hidden = self.hidden || container.display == Display::None;
         let node = self.tree.borrow_mut().push(
             Some(self.parent),
             Kind::Container(container.clone()),
@@ -1914,6 +1927,7 @@ impl LiteCx<'_> {
             root_ui: self.root_ui,
             root_min: self.root_min,
             parent: node,
+            hidden,
             child_index: &mut used,
         };
         f(&mut child)
@@ -1960,12 +1974,30 @@ impl LiteCx<'_> {
                     .unwrap_or_else(|| Rect::from_min_size(self.root_min, Vec2::ZERO)),
             )
             .id_salt(scope.with(index));
-        if rect.is_none() {
+        if rect.is_none() || self.hidden {
             builder = builder.sizing_pass().invisible();
-            self.tree.borrow_mut().created = true;
+            // A hidden leaf's draw is not a measurement anyone waits for, so
+            // it is not a reason to draw the row again.
+            if rect.is_none() && !self.hidden {
+                self.tree.borrow_mut().created = true;
+            }
         }
         let mut ui = self.root_ui.new_child(builder);
+        if self.hidden {
+            // One hidden accesskit node over the whole leaf; see
+            // `super::TreeCx::leaf`.
+            ui.ctx().accesskit_node_builder(ui.unique_id(), |node| {
+                node.set_role(egui::accesskit::Role::GenericContainer);
+                node.set_hidden();
+            });
+        }
         let inner = f(&mut ui);
+
+        if self.hidden {
+            // The measure from the last visible draw stays on the node: the
+            // solver zeroes a hidden subtree whatever it says.
+            return inner;
+        }
 
         if measured {
             let min_size = ui.min_size().ceil();
@@ -2012,6 +2044,14 @@ impl LiteCx<'_> {
             let galley = tree.texts[slot].galley(fonts, wrap_width(&content, wrap));
             (node, last.is_some(), content, galley)
         };
+
+        if self.hidden {
+            // The text and the node are pushed; nothing is registered. Same
+            // reasons as `super::TreeCx::text`.
+            return self
+                .root_ui
+                .interact(Rect::NOTHING, scope.with(index), egui::Sense::hover());
+        }
 
         let rect = galley_rect(&content, &galley);
         let selectable =
@@ -2138,12 +2178,14 @@ pub(crate) fn supported(
 /// leaf at last frame's rect, solve, decide about a second pass, paint the
 /// texts where the solver put them, and reserve exactly the size the caller
 /// asked for.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn show<R>(
     tree: &Rc<RefCell<LiteTree>>,
     ui: &mut egui::Ui,
     container: &ContainerStyle,
     item: &ItemStyle,
     size: Vec2,
+    hidden: bool,
     f: impl FnOnce(&mut LiteCx<'_>) -> R,
 ) -> R {
     let root_min = ui.available_rect_before_wrap().min;
@@ -2168,6 +2210,8 @@ pub(crate) fn show<R>(
             root_ui: &mut root_ui,
             root_min,
             parent: 0,
+            // A row drawn inside a hidden leaf is hidden from its root.
+            hidden,
             child_index: &mut used,
         };
         f(&mut cx)

--- a/crates/egui-react/src/engine/mod.rs
+++ b/crates/egui-react/src/engine/mod.rs
@@ -780,6 +780,12 @@ pub(crate) struct TreeCx<'u> {
     /// `<Text>` reads this to decide whether it may paint itself right away
     /// (see [`TreeCx::text`]).
     placed: bool,
+    /// Is this position inside a `display="none"` subtree?
+    ///
+    /// Everything under such a node is laid out at zero by taffy, so its
+    /// leaves draw invisible, out of the accessibility tree, and its texts
+    /// register nothing at all.
+    hidden: bool,
     /// How many children have been added under `parent` so far.
     child_index: &'u mut usize,
 }
@@ -793,8 +799,14 @@ impl TreeCx<'_> {
             parent: self.parent,
             origin: self.origin,
             placed: self.placed,
+            hidden: self.hidden,
             child_index: self.child_index,
         }
+    }
+
+    /// Is this position inside a `display="none"` subtree?
+    pub(crate) fn hidden(&self) -> bool {
+        self.hidden
     }
 
     /// The tree's own `Ui`, which is what `cx.ui()` returns in tree mode.
@@ -825,6 +837,10 @@ impl TreeCx<'_> {
         f: impl FnOnce(&mut TreeCx<'_>) -> R,
     ) -> R {
         let index = self.next_index();
+        // The node is still added and `f` still runs: keys and child indices
+        // stay stable, so a show after a hide is not a "created" pass, and the
+        // components inside keep their hooks.
+        let hidden = self.hidden || style.display == taffy::Display::None;
         let (node, layout, first_frame) =
             self.tree
                 .borrow_mut()
@@ -839,6 +855,7 @@ impl TreeCx<'_> {
                 parent: node,
                 origin,
                 placed: self.placed && !first_frame,
+                hidden,
                 child_index: &mut used,
             };
             f(&mut child)
@@ -872,17 +889,40 @@ impl TreeCx<'_> {
         let mut builder = UiBuilder::new()
             .max_rect(content_rect(&layout, self.origin))
             .id_salt(scope.with(index));
-        if first_frame {
+        if first_frame || self.hidden {
             // A node that has never been laid out has a zero rect, so its
             // first draw is a measurement: invisible, and in a sizing pass so
             // that widgets ask for as little space as they can. That is the
             // one reason a frame always needs a second pass, so it is recorded
-            // here rather than wherever a node happens to be created.
+            // here rather than wherever a node happens to be created. A hidden
+            // leaf draws the same way, but nobody waits for its size, so it is
+            // not a reason for a second pass.
             builder = builder.sizing_pass().invisible();
-            self.tree.borrow_mut().created_this_frame = true;
+            if first_frame && !self.hidden {
+                self.tree.borrow_mut().created_this_frame = true;
+            }
         }
         let mut ui = self.root_ui.new_child(builder);
+        if self.hidden {
+            // Every widget `f` registers hangs from the `Ui`'s own id
+            // (`Ui::interact` -> `register_accesskit_parent`), so one hidden
+            // node here hides the whole subtree from assistive technology:
+            // `accesskit_consumer::common_filter` excludes a hidden node with
+            // everything under it. egui registers the widgets whether they are
+            // visible or not (5.8), so this is the one way to keep them out.
+            ui.ctx().accesskit_node_builder(ui.unique_id(), |node| {
+                node.set_role(egui::accesskit::Role::GenericContainer);
+                node.set_hidden();
+            });
+        }
         let inner = f(&mut ui);
+
+        if self.hidden {
+            // taffy lays a `Display::None` subtree out at zero whatever the
+            // measure says, and the measure from the last visible draw is
+            // what the node needs when it comes back.
+            return inner;
+        }
 
         let measure = if measured {
             let min_size = ui.min_size().ceil();
@@ -952,6 +992,19 @@ impl TreeCx<'_> {
         let content = content_rect(&layout, self.origin);
 
         let (job, hash) = text_job(self.root_ui, text);
+        if self.hidden {
+            // The galley cache and the node's text survive, so a show costs no
+            // more than a visible frame. Nothing else is registered: no
+            // `WidgetInfo` (so no accesskit node), no selection state, no shape
+            // and no pending text. The rect nothing can hit is what a caller
+            // reading the `Response` sees.
+            self.tree
+                .borrow_mut()
+                .set_text(node, Arc::clone(&job), hash, wrap);
+            return self
+                .root_ui
+                .interact(Rect::NOTHING, scope.with(index), egui::Sense::hover());
+        }
         let fonts = Fonts::of(self.root_ui);
         let galley = {
             let mut tree = self.tree.borrow_mut();
@@ -1181,6 +1234,8 @@ pub(crate) fn show<R>(
             parent: root,
             origin: border_box_min(&root_layout, root_rect.min),
             placed: !first_frame,
+            // A tree opened inside a hidden leaf is hidden from its root.
+            hidden: store.in_hidden(),
             child_index: &mut used,
         };
         f(&mut tc)

--- a/crates/egui-react/src/hooks.rs
+++ b/crates/egui-react/src/hooks.rs
@@ -1,4 +1,5 @@
-//! The hooks: `use_state`, `use_handle`, `use_memo`, `use_effect`, `use_persisted`.
+//! The hooks: `use_state`, `use_handle`, `use_memo`, `use_effect`, `use_persisted`,
+//! `use_animate`.
 
 use std::any::Any;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -167,4 +168,26 @@ where
     let cleanup = f().into_cleanup();
     slot.set_cleanup(cleanup);
     slot.set_deps_hash(hash);
+}
+
+/// egui's `animate_bool_with_time_and_easing` behind a hook: 0 while `on` is
+/// false, 1 while it is true, and in between for `time` seconds after `on`
+/// flips, eased with `cubic_out`.
+///
+/// egui's `AnimationManager` owns the value and asks for the repaints while it
+/// moves, so nothing is stored in the `Store` and the repaint policy (5.6) is
+/// untouched. No `Store` slot means no sweep either: the animation of a
+/// component that stops being drawn stays in egui's memory at its last value,
+/// which is what `animate_bool` does for everyone.
+#[track_caller]
+pub fn use_animate(cx: &mut Cx<'_, '_>, on: bool, time: f32) -> f32 {
+    use_animate_with(cx, on, time, egui::emath::easing::cubic_out)
+}
+
+/// [`use_animate`] with an easing of the caller's choosing (`egui::emath::easing`).
+#[track_caller]
+pub fn use_animate_with(cx: &mut Cx<'_, '_>, on: bool, time: f32, easing: fn(f32) -> f32) -> f32 {
+    let id = cx.scope_id().with(location_key(Location::caller()));
+    cx.ctx()
+        .animate_bool_with_time_and_easing(id, on, time, easing)
 }

--- a/crates/egui-react/src/layout.rs
+++ b/crates/egui-react/src/layout.rs
@@ -604,3 +604,34 @@ impl ContainerStyle {
         style
     }
 }
+
+/// The taffy style of the root container: a column that fills the window.
+///
+/// `reserve_available_space` tells the layout engine how much room there is,
+/// but it leaves the root node's own `size` at `auto`, so taffy would size that
+/// node by its content. Two things go wrong then. A `<View grow={1.0}
+/// justify="center">` child finds no free space to grow into and nothing to be
+/// centred in, so the app sits in the window's top-left corner. And a child
+/// too wide to fit never has to shrink, because a content-sized parent simply
+/// grows with it and there is no overflow to resolve — the row runs off the
+/// right edge instead of `grow` and `flex-shrink` sharing out what there is.
+///
+/// So both sides are fixed at 100%: a window is exactly as big as it is. The
+/// height used to be only a *minimum* of 100%, so that a column taller than
+/// the window would lay out at its own height. That let a `leaf_fill` (a
+/// `<ScrollArea>`, a `<VirtualList>`) push the root past the window: such a
+/// leaf reports the whole root height as its content size, so a column of
+/// "a header, then a list that fills the rest" measured as header plus window,
+/// and the root grew to fit — the list's last rows sat below the window edge.
+/// With a definite height the header keeps its content height (a flex item's
+/// automatic minimum) and the list gets what is left. Content taller than the
+/// window still overflows it rather than being shrunk, for the same reason,
+/// and belongs in a `ScrollArea` as it always did.
+///
+/// Exposed so a runner, a test or an element that roots a tree of its own
+/// (`<Overlay>`) all use the same style.
+pub fn root_style() -> taffy::Style {
+    ContainerStyle::default()
+        .direction("column")
+        .merge(&ItemStyle::default().w("100%").h("100%"))
+}

--- a/crates/egui-react/src/lib.rs
+++ b/crates/egui-react/src/lib.rs
@@ -23,7 +23,8 @@ pub use dispatch::{Dispatch, use_reducer};
 pub use events::{Arity0, Arity1, Emitter, EventSink, Handler};
 pub use future::{SpawnFuture, spawn, use_future};
 pub use hooks::{
-    FnCleanup, IntoCleanup, NoCleanup, use_effect, use_handle, use_memo, use_persisted, use_state,
+    FnCleanup, IntoCleanup, NoCleanup, use_animate, use_animate_with, use_effect, use_handle,
+    use_memo, use_persisted, use_state,
 };
 pub use layout::{
     Align, AlignSelf, ContainerStyle, Direction, Display, Gap, ItemStyle, Justify, Length,
@@ -97,7 +98,9 @@ pub mod prelude {
     pub use crate::dispatch::{Dispatch, use_reducer};
     pub use crate::events::{Emitter, EventSink, Handler};
     pub use crate::future::{spawn, use_future};
-    pub use crate::hooks::{use_effect, use_handle, use_memo, use_persisted, use_state};
+    pub use crate::hooks::{
+        use_animate, use_animate_with, use_effect, use_handle, use_memo, use_persisted, use_state,
+    };
     pub use crate::layout::{
         Align, AlignSelf, ContainerStyle, Direction, Display, Gap, ItemStyle, Justify, Length,
     };

--- a/crates/egui-react/src/store.rs
+++ b/crates/egui-react/src/store.rs
@@ -180,6 +180,8 @@ pub struct Store {
     /// Draw every row through taffy, whatever its styles say. For the parity
     /// test, which draws the same row both ways.
     force_taffy_rows: Cell<bool>,
+    /// How many hidden leaves are being drawn right now (nested leaves count up).
+    hidden: Cell<u32>,
     warn_on_collision: bool,
 }
 
@@ -223,6 +225,7 @@ impl Store {
             trees: RefCell::new(HashMap::new()),
             lite_trees: RefCell::new(HashMap::new()),
             force_taffy_rows: Cell::new(false),
+            hidden: Cell::new(0),
             warn_on_collision: cfg!(debug_assertions),
         }
     }
@@ -234,6 +237,22 @@ impl Store {
         self.collisions.borrow_mut().clear();
         self.contexts.borrow_mut().clear();
         self.suspense.borrow_mut().clear();
+        // A panic inside a hidden leaf must not leave the count raised.
+        self.hidden.set(0);
+    }
+
+    /// Mark everything drawn while the guard lives as hidden.
+    ///
+    /// `Cx::leaf` holds one while a `display="none"` leaf draws, so a tree the
+    /// leaf opens over its own `Ui` starts hidden too.
+    pub(crate) fn enter_hidden(&self) -> HiddenGuard<'_> {
+        self.hidden.set(self.hidden.get() + 1);
+        HiddenGuard { store: self }
+    }
+
+    /// Is a hidden leaf being drawn right now?
+    pub fn in_hidden(&self) -> bool {
+        self.hidden.get() > 0
     }
 
     /// Finish the pass: apply the deferred queue, then sweep, then warn.
@@ -610,5 +629,16 @@ impl Store {
             log::warn!("egui-react: could not write persisted state: {err}");
             String::from("{}")
         })
+    }
+}
+
+/// What [`Store::enter_hidden`] returns: the count goes back down on drop.
+pub(crate) struct HiddenGuard<'s> {
+    store: &'s Store,
+}
+
+impl Drop for HiddenGuard<'_> {
+    fn drop(&mut self) {
+        self.store.hidden.set(self.store.hidden.get() - 1);
     }
 }

--- a/crates/egui-react/tests/animate.rs
+++ b/crates/egui-react/tests/animate.rs
@@ -1,0 +1,88 @@
+//! Plan 9.1: `use_animate` is 0 while `on` is false, 1 while it is true, and
+//! moves between them over `time` seconds. The value lives in egui's
+//! `AnimationManager`, so a step of the harness is a step of the animation.
+
+mod common;
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use common::run_app;
+use egui_kittest::Harness;
+use egui_react::prelude::*;
+
+/// A frame every twentieth of a second: with `time` 0.5 the value moves by
+/// 0.1 per step, so it takes ten steps to go from 0 to 1.
+const STEP_DT: f32 = 0.05;
+
+/// A harness whose app writes `use_animate(on, time)` into `value` each frame.
+fn animating<'a>(on: &Rc<Cell<bool>>, value: &Rc<Cell<f32>>, time: f32) -> Harness<'a, Store> {
+    let on = Rc::clone(on);
+    let value = Rc::clone(value);
+    Harness::builder().with_step_dt(STEP_DT).build_ui_state(
+        move |ui, store: &mut Store| {
+            let (on, value) = (Rc::clone(&on), Rc::clone(&value));
+            run_app(ui, store, move |cx| {
+                let v = use_animate(cx, on.get(), time);
+                value.set(v);
+                cx.ui().label(format!("v: {v}"));
+            });
+        },
+        Store::new(),
+    )
+}
+
+#[test]
+fn off_is_zero_and_on_rises_to_one_over_time() {
+    let on = Rc::new(Cell::new(false));
+    let value = Rc::new(Cell::new(-1.0));
+    let mut harness = animating(&on, &value, 0.5);
+
+    harness.step();
+    assert_eq!(value.get(), 0.0, "an animation that is off sits at zero");
+
+    // The first step after the flip is on the way up, not there yet.
+    on.set(true);
+    harness.step();
+    let first = value.get();
+    assert!(0.0 < first && first < 1.0, "mid-animation, got {first}");
+
+    // Collect the rest of the climb: never going back, ending exactly at 1.
+    let mut values = vec![first];
+    for _ in 0..12 {
+        if values[values.len() - 1] == 1.0 {
+            break;
+        }
+        harness.step();
+        values.push(value.get());
+    }
+    for pair in values.windows(2) {
+        assert!(pair[0] <= pair[1], "the value went back down: {values:?}");
+    }
+    assert_eq!(values[values.len() - 1], 1.0, "never arrived: {values:?}");
+    assert!(values.len() >= 8, "arrived too fast: {values:?}");
+
+    // And back down the same way.
+    on.set(false);
+    harness.step();
+    let falling = value.get();
+    assert!(falling < 1.0, "still at the top, got {falling}");
+    for _ in 0..12 {
+        harness.step();
+    }
+    assert_eq!(value.get(), 0.0, "never got back to zero");
+}
+
+#[test]
+fn zero_time_flips_at_once() {
+    let on = Rc::new(Cell::new(false));
+    let value = Rc::new(Cell::new(-1.0));
+    let mut harness = animating(&on, &value, 0.0);
+
+    harness.step();
+    assert_eq!(value.get(), 0.0);
+
+    on.set(true);
+    harness.step();
+    assert_eq!(value.get(), 1.0, "a zero-second animation has no middle");
+}

--- a/crates/egui-react/tests/hidden.rs
+++ b/crates/egui-react/tests/hidden.rs
@@ -1,0 +1,167 @@
+//! Plan 9.6: `display="none"` takes a subtree out of the layout without
+//! unmounting it.
+//!
+//! The container's node stays, so keys and child indices do not move and the
+//! components inside keep their hooks; taffy lays the subtree out at zero, its
+//! leaves draw into an invisible sizing `Ui` under one hidden accesskit node,
+//! and a `<Text>` registers nothing at all.
+//!
+//! Core APIs only (`cx.container`, `cx.leaf`, `cx.text`, `use_state`), as
+//! `taffy_cx.rs` does.
+
+mod common;
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use common::run_app;
+use egui_kittest::Harness;
+use egui_kittest::kittest::{NodeT as _, Queryable as _};
+use egui_react::prelude::*;
+
+/// The gap between the row's leaves, which is what the hidden node must not add
+/// a second time.
+const GAP: f32 = 8.0;
+
+/// A row: leaf `a`, a container that is hidden or not, leaf `b`.
+///
+/// Inside the container: a counter (state, a button, a `<Text>`), a plain
+/// `<Text>`, and a leaf that opens a tree of its own.
+fn app(cx: &mut Cx<'_, '_>, shown: bool) {
+    let row = ContainerStyle::default().direction("row").gap(GAP);
+    cx.container(egui::Id::new("row"), &row, &ItemStyle::default(), |cx| {
+        cx.scope("a", |cx| {
+            cx.leaf(&ItemStyle::default(), |ui| ui.button("a"));
+        });
+
+        let inner = ContainerStyle::default()
+            .direction("column")
+            .display(if shown { "flex" } else { "none" });
+        cx.scope("inner", |cx| {
+            let id = cx.layout_id();
+            cx.container(id, &inner, &ItemStyle::default(), |cx| {
+                cx.scope("counter", |cx| {
+                    let mut count = use_state(cx, || 0i32);
+                    let clicked = cx.leaf(&ItemStyle::default(), |ui| ui.button("hidden +"));
+                    if clicked.clicked() {
+                        *count += 1;
+                    }
+                    let label = format!("count: {}", *count);
+                    cx.text(&ItemStyle::default(), label.into(), false, Some(false));
+                });
+                cx.scope("text", |cx| {
+                    cx.text(
+                        &ItemStyle::default(),
+                        "hidden text".into(),
+                        false,
+                        Some(false),
+                    );
+                });
+                // A leaf that opens a tree of its own: it starts hidden too,
+                // through the store's counter.
+                cx.scope("nested", |cx| {
+                    let (store, scope) = (cx.store, cx.scope_id());
+                    cx.leaf(&ItemStyle::default(), move |ui| {
+                        let mut cx = Cx::new(store, ui, scope);
+                        let column = ContainerStyle::default().direction("column");
+                        cx.container(scope.with("tree"), &column, &ItemStyle::default(), |cx| {
+                            cx.text(
+                                &ItemStyle::default(),
+                                "nested text".into(),
+                                false,
+                                Some(false),
+                            );
+                        });
+                    });
+                });
+            });
+        });
+
+        cx.scope("b", |cx| {
+            cx.leaf(&ItemStyle::default(), |ui| ui.button("b"));
+        });
+    });
+}
+
+fn harness_for(shown: &Rc<Cell<bool>>) -> Harness<'static, Store> {
+    let shown = Rc::clone(shown);
+    let mut harness = Harness::new_ui_state(
+        move |ui, store: &mut Store| {
+            let shown = shown.get();
+            run_app(ui, store, move |cx| app(cx, shown));
+        },
+        Store::new(),
+    );
+    harness.run();
+    harness
+}
+
+#[test]
+fn a_hidden_view_takes_no_space_and_reports_no_text() {
+    let shown = Rc::new(Cell::new(true));
+    let mut harness = harness_for(&shown);
+
+    // Drawn: every text in the subtree is in the tree kittest queries.
+    assert!(harness.query_by_label("count: 0").is_some());
+    assert!(harness.query_by_label("hidden text").is_some());
+    assert!(harness.query_by_label("nested text").is_some());
+
+    // Hidden: one frame to lay the row out again, one to draw it.
+    shown.set(false);
+    harness.run();
+    harness.run();
+    assert!(harness.query_by_label("count: 0").is_none());
+    assert!(harness.query_by_label("hidden text").is_none());
+    assert!(
+        harness.query_by_label("nested text").is_none(),
+        "a tree opened inside a hidden leaf is hidden too"
+    );
+
+    // The row closes over the gap the hidden node used to take.
+    let a = harness.get_by_label("a").rect();
+    let b = harness.get_by_label("b").rect();
+    assert!(
+        (b.left() - (a.right() + GAP)).abs() <= 1.0,
+        "the hidden node still takes room: {a:?} {b:?}"
+    );
+
+    // A hidden widget is still registered by egui (5.8), so what keeps it away
+    // from assistive technology is the hidden node its `Ui` hangs from.
+    let button = harness.get_by_label("hidden +");
+    let parent = button
+        .accesskit_node()
+        .parent()
+        .expect("the leaf's `Ui` node");
+    assert!(parent.is_hidden(), "the leaf's node should be hidden");
+}
+
+#[test]
+fn state_survives_a_hide_and_a_show() {
+    let shown = Rc::new(Cell::new(true));
+    let mut harness = harness_for(&shown);
+
+    harness.get_by_label("hidden +").click();
+    harness.run();
+    assert!(harness.query_by_label("count: 1").is_some());
+    let slots = harness.state().len();
+    assert_eq!(slots, 1, "one slot: the counter's state");
+
+    // Hidden: the component still runs, so its slot is visited and swept by
+    // nobody.
+    shown.set(false);
+    harness.run();
+    harness.run();
+    assert_eq!(harness.state().len(), slots, "the state was swept away");
+
+    // Pressing where the hidden button reports itself does nothing.
+    harness.get_by_label("hidden +").click();
+    harness.run();
+
+    shown.set(true);
+    harness.run();
+    harness.run();
+    assert!(
+        harness.query_by_label("count: 1").is_some(),
+        "the count should come back as it was"
+    );
+}

--- a/crates/egui-react/tests/lite_parity.rs
+++ b/crates/egui-react/tests/lite_parity.rs
@@ -322,6 +322,46 @@ fn shrinking(cx: &mut Cx<'_, '_>, rects: &Rects) {
     );
 }
 
+/// A hidden child holding a leaf and a `<Text>`: both paths draw the leaf into
+/// an invisible `Ui` at the row's corner and register the text at
+/// `Rect::NOTHING`.
+fn hidden_in_row(cx: &mut Cx<'_, '_>, rects: &Rects) {
+    let style = row().gap(4.0);
+    view(
+        cx,
+        "root",
+        &style,
+        &ItemStyle::default().w("100%").h("100%"),
+        |cx| {
+            leaf(
+                cx,
+                rects,
+                "before",
+                &ItemStyle::default(),
+                egui::vec2(20.0, 10.0),
+            );
+            let gone = ContainerStyle::default().display("none");
+            view(cx, "gone", &gone, &ItemStyle::default().w(50.0), |cx| {
+                leaf(
+                    cx,
+                    rects,
+                    "hidden leaf",
+                    &ItemStyle::default(),
+                    egui::vec2(10.0, 10.0),
+                );
+                text(cx, rects, "hidden text", &ItemStyle::default(), "gone");
+            });
+            leaf(
+                cx,
+                rects,
+                "after",
+                &ItemStyle::default(),
+                egui::vec2(20.0, 10.0),
+            );
+        },
+    );
+}
+
 /// A `display: none` child, which takes no space and gets no box.
 fn display_none(cx: &mut Cx<'_, '_>, rects: &Rects) {
     let style = row().gap(4.0);
@@ -598,6 +638,7 @@ const CORPUS: &[(&str, Case)] = &[
     ("align_variants", align_variants),
     ("shrinking", shrinking),
     ("display_none", display_none),
+    ("hidden_in_row", hidden_in_row),
     ("min_max_clamping", min_max_clamping),
     ("column_direction", column_direction),
     ("row_reverse", row_reverse),
@@ -685,6 +726,15 @@ fn draw_with(case: Case, taffy: bool, expect_lite: bool) -> Vec<(&'static str, e
     last
 }
 
+/// Do the two paths agree on one node's rect?
+///
+/// Plain equality, except that a hidden `<Text>` registers `Rect::NOTHING`,
+/// and translating that by the row's origin gives NaN, which is not equal to
+/// itself. Two rects that are both nothing are the same answer.
+fn same_rect(a: &egui::Rect, b: &egui::Rect) -> bool {
+    a == b || (a.any_nan() && b.any_nan())
+}
+
 #[test]
 fn the_lite_path_and_taffy_agree_on_every_corpus_row() {
     let mut failures = Vec::new();
@@ -700,7 +750,7 @@ fn the_lite_path_and_taffy_agree_on_every_corpus_row() {
             continue;
         }
         for ((node, lite), (_, taffy)) in lite.iter().zip(taffy.iter()) {
-            if lite != taffy {
+            if !same_rect(lite, taffy) {
                 failures.push(format!("{name}/{node}: lite {lite:?} != taffy {taffy:?}"));
             }
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,7 @@ The main methods are below.
 |---|---|
 | `ui() -> &mut egui::Ui` | The current `Ui`. In tree mode, the tree's own `Ui`: an escape hatch that does not get taffy placement, and what a docked `<Panel>` carves its space out of |
 | `ctx() -> &egui::Context` / `scope_id() -> Id` / `layout_id() -> Id` | Accessors |
+| `is_hidden() -> bool` | Whether we are inside a `display="none"` subtree. True on both layout paths, and inside anything a leaf of a hidden view opens (see Layout in section 6) |
 | `in_taffy() -> bool` | Whether we are inside a `<View>`. True on both layout paths, the taffy one and the lite one: what an element reads it for is whether the layout decides its size, and that is the same either way |
 | `scope(source, f)` | Goes one level deeper in component scope. Both Ids deepen. Ui mode also calls `ui.push_id`; tree mode pushes no `Ui`, because a node is a rect |
 | `hook_scope(location, f)` | Scope for a custom hook. Does not touch egui Ids |
@@ -203,6 +204,7 @@ The second is "passing to the same element both a value prop that borrows state 
 | `use_persisted(cx, "key", init) -> State<T>` | `T: Serialize + DeserializeOwned`. Saved to eframe storage and survives restarts. The key is an explicit string (see below) |
 | `use_memo(cx, deps, f) -> &T` | Re-runs `f` only when the hash of deps changes |
 | `use_effect(cx, deps, f)` | Runs `f` **in place** when deps change (and the first time). `f` may return a cleanup (`FnOnce + 'static`) |
+| `use_animate(cx, on, time) -> f32` / `use_animate_with(cx, on, time, easing)` | 0 while `on` is false, 1 while it is true, and eased between the two for `time` seconds after `on` flips (`cubic_out`, or the easing you pass). egui's `AnimationManager` owns the value and asks for the repaints while it moves, so there is no slot in the store and nothing for the sweep to drop: the animation of a component that stops being drawn stays in egui's memory at its last value, as `animate_bool` does for everyone |
 | `use_reducer(cx, reducer, init) -> (State<S>, Dispatch<Msg>)` | `Dispatch` is `Clone + Send + 'static`. `send` pushes onto a queue and calls `request_repaint`; the reducer is applied in order **the next time the hook is visited** (see below) |
 | `provide_context(cx, handle, children)` / `use_context::<T>(cx) -> Option<Handle<T>>` | Valid only while descendants render. Returns a `Handle`, not a guard (to avoid a double borrow with the parent's guard). The store holds a stack of `(TypeId, slot Id)`, and `use_context` rebuilds a `Handle` from the slot Id. `Handle` itself carries `'s`, so it cannot go into `dyn Any` |
 | `use_future(cx, deps, \|\| async { .. }) -> &Poll<T>` | Rebuilds and starts the future each time the hash of deps changes. Native uses one thread + `pollster::block_on`, wasm uses `wasm_bindgen_futures::spawn_local`. On completion it writes the result to the slot and calls `request_repaint`. Stale results that arrive after deps changed are dropped. `Pending` is counted toward the nearest `<Suspense>` (see below) |
@@ -311,7 +313,7 @@ When a handler or effect rewrites state, widgets drawn earlier in the same compo
 
 - **Counter stack** `Store` holds a `RefCell<Vec<usize>>` in the same shape as `provide_context`. `begin_suspense` pushes 0, `end_suspense` returns the pushed count (= the number of `use_future`s that were `Pending` inside), and `note_pending` adds 1 to the nearest (= innermost) counter. With nesting, the inner one consumes its own count, so the outer one does not count it. The stack is cleared in `begin_pass`. Only these 3 methods are added to core; the boundary itself lives in elements (an "element that wraps children", like `Collapsing`).
 - **Initial state is suspended** The first time, draw offscreen, then switch to visible if there is no `Pending`. This is so that when `max_passes` runs out and `request_discard` is refused, what shows is `fallback` rather than half-drawn children.
-- **Children are drawn while suspended too** They are drawn into an offscreen invisible `Ui` (`egui::Ui::new(ctx, id, UiBuilder::new().max_rect(fixed offscreen rect).invisible().sizing_pass())`). Hooks run, and futures start and complete. The rect is a fixed value so the layout engine sees the same size every pass and does not issue useless `request_discard`s. `invisible()` disables both drawing and interaction, so the children's handlers do not fire offscreen. However, egui creates accessibility nodes for widgets regardless of visibility, so screen readers and `egui_kittest` see suspended children as "nodes at offscreen coordinates".
+- **Children are drawn while suspended too** They are drawn into an offscreen invisible `Ui` (`egui::Ui::new(ctx, id, UiBuilder::new().max_rect(fixed offscreen rect).invisible().sizing_pass())`). Hooks run, and futures start and complete. The rect is a fixed value so the layout engine sees the same size every pass and does not issue useless `request_discard`s. `invisible()` disables both drawing and interaction, so the children's handlers do not fire offscreen. However, egui creates accessibility nodes for widgets regardless of visibility, so screen readers and `egui_kittest` see suspended children as "nodes at offscreen coordinates". A hidden `<View>` (`display="none"`, section 6) works around the same limit by giving the leaf's `Ui` a hidden accesskit node that its widgets hang from; `Suspense` could take that route too.
 - **Children scope** Both suspended and visible paths use the `scope_id()` of `Suspense` itself (the third argument of `Cx::new(store, &mut ui, scope)`). The hook slots having the same Id on both paths is what preserves state and futures across the switch. `fallback` is drawn into the same `cx`, but the `rsx!` element Ids differ by line and column, so it does not collide with children.
 - **The switch happens within the same frame** At the moment of the switch, flip the state with `Handle::set` and redo the same frame with `request_discard`. Neither half-drawn children nor a one-frame gap between fallback and children is visible. `Handle::set` calls `request_repaint`, but it is only called at the switch, so it does not repaint every frame while suspended. If `max_passes` (runner default 3) runs out and the discard is refused, the runner calls `request_repaint` and it settles on the next frame.
 - **`shares_ui`** `Suspense` creates no `Ui` / leaf of its own; it streams children and fallback into the parent surface (Ui or Taffy) as-is. Placed inside a `<View>`, the children's `<View>` become children of the parent's taffy tree.
@@ -356,6 +358,23 @@ The rest, unchanged by the engine:
 - egui's standard containers such as `<Vertical>` / `<Horizontal>` / `<Grid>` remain as leaves, as an escape hatch where performance matters. When called from Taffy mode, these egui-native containers behave as a single leaf, and the children inside are drawn in Ui mode. Only `ScrollArea` is placed with `leaf_fill` (3.1). It is a widget that fills the given space, so a leaf measured by content would lock it to the size of the first frame. Give a `ScrollArea` inside a `<View>` either `grow` or `h`. **The max-content of `leaf_fill` is exactly "the height of the current tree's root rect"** (the engine's measure function reads `infinite` that way, as egui_taffy's did), so inside a `<View direction="column">` with no definite height, neither `grow` nor `basis={0}` works, and the `ScrollArea` asks for "the whole window height" rather than "what is left after siblings". A screen with a `ScrollArea` under a toolbar becomes taller than the window by that much, and since the runner's root item style is `min_h: 100%` (section 7) with the height itself auto, the overflow is not clipped and extends downward. Either give it a definite height, or arrange things so nothing sits at the bottom edge that would get pushed out (`examples/board` puts the column's `+ card` at the end inside the `ScrollArea`. `docs/tasks/board/plan.md` 8.3).
 - Every leaf that carries text sets wrap to `Extend` (`Text` `Label` `Button` `Checkbox` `Slider` `ComboBox` labels, the `Collapsing` header). The engine measures a widget leaf as "the size it was drawn at last time" and returns that single value to taffy as both min-content and max-content. (`<Text>` no longer goes through this: the engine lays its galley out itself and knows its real width. The `Extend` default stays, because it is also what `<Text>` means without `wrap`.) The first draw happens in a `Ui` of width 0, so a wrapping widget reports "one character wide" there, the node is locked at that narrow width, and the label stacks one character per line. Leaves with `grow` or `w` are unaffected because taffy decides their width. Widgets with a `wrap_mode` builder (`Button` / `Label`) use it; those without (`Checkbox` / `Slider` / `ComboBox` / `CollapsingHeader`) set it on the leaf `Ui`'s `style.wrap_mode`. `Collapsing` restores the original value before entering the body (what the children draw is the caller's business).
 - Both `<Text>` and `<Label>` can switch to egui's default wrapping with the `wrap` attribute. Wrapping needs a width, so use it together with `w` or (inside a container with a definite width) `grow`. The only difference between the two is that `Text` has `size` / `color` / `strong`.
+- **`display="none"` hides a subtree without unmounting it.** The node stays in
+  the tree, so keys and child indices do not move and every component inside
+  keeps running and keeps its hooks; the layout gives the node and everything
+  under it a zero box, on the taffy path and on the lite one alike. What is
+  drawn under it is drawn into an invisible sizing `Ui`, which egui still
+  registers widgets in (5.8), so the leaf's `Ui` gets an accesskit node of its
+  own, role `GenericContainer`, marked hidden: `accesskit_consumer`'s common
+  filter drops a hidden node together with its subtree, so assistive technology
+  sees none of it. A `<Text>` registers nothing at all — no galley shape, no
+  `WidgetInfo`, no accesskit node — and returns a response at `Rect::NOTHING`.
+  `cx.is_hidden()` (3.1) answers "am I inside one", including inside a tree a
+  hidden leaf opens over its own `Ui`; `Window`, `Overlay`, `Panel` and
+  `CentralPanel` read it and draw nothing, because an `Area` is a layer of its
+  own and a docked panel draws into the tree's root `Ui`, so neither is reached
+  by an invisible leaf `Ui`. Use it for a pane that has to keep its state while
+  something else is on screen (the gallery keeps the running example mounted
+  while its code is up); use `if` and the sweep when the state should go.
 - The root panel is wrapped by default in a `<View>` with `direction="column"`.
 
 ### Elements list (`egui-react-elements`)
@@ -365,12 +384,34 @@ All elements are written with `#[component]` and take `#[prop(default)] style: I
 | Kind | Elements |
 |---|---|
 | Layout | `View` (`display` / `direction` / `wrap` / `justify` / `align` / `align_content` / `gap` / `cols`), `Text` (`size` / `color` / `strong` / `wrap`) |
-| Widgets | `Button` (`enabled` / `label`, `on_click`), `Label` (`wrap`), `TextEdit` (`bind` / `multiline` / `hint` / `desired_width` / `rows`, `on_change` / `on_submit`), `Checkbox` (`bind` / `label`, `on_change`), `Slider<T: Numeric>` (`bind` / `range` / `label`, `on_change`), `ComboBox` (`bind` / `options` / `label`, `on_change`), `Image` (`source` / `fit` / `alt`), `Separator` (`vertical`) |
-| Containers | `ScrollArea`, `VirtualList` (`rows` / `row_h` / `render`), `Collapsing`, `Frame`, `Window` (`title` / `open` / `resizable` / `default_pos` / `default_size`), `Panel` (`side`), `CentralPanel`, `Vertical`, `Horizontal`, `Grid` + `row()` |
+| Widgets | `Button` (`enabled` / `label` / `padding` / `corner_radius`, `on_click`), `Label` (`wrap`), `TextEdit` (`bind` / `multiline` / `hint` / `desired_width` / `rows`, `on_change` / `on_submit`), `Checkbox` (`bind` / `label`, `on_change`), `Slider<T: Numeric>` (`bind` / `range` / `label`, `on_change`), `ComboBox` (`bind` / `options` / `label`, `on_change`), `Image` (`source` / `fit` / `alt`), `Separator` (`vertical`) |
+| Containers | `ScrollArea`, `VirtualList` (`rows` / `row_h` / `render`), `Collapsing`, `Frame` (`fill` / `stroke` / `inner_margin` / `corner_radius` / `shadow` / `custom_shadow`), `Window` (`title` / `open` / `resizable` / `default_pos` / `default_size`), `Overlay` (`anchor` / `offset` / `pos` / `order` / `constrain` / `top` / `fill`; sized by `w` / `h`, or by its children), `Panel` (`side`), `CentralPanel`, `Vertical`, `Horizontal`, `Grid` + `row()` |
 | Drawing | `Canvas` (`sense` / `paint`, `on_drag` / `on_hover`. A leaf that passes on the rect taffy gave it as-is) |
 | Async | `Suspense` (`fallback: impl View`, `shares_ui`. Draws `fallback` instead of children if even one `use_future` inside is `Pending`. 5.8) |
 
 `label` on `Button` and `alt` on `Image` are the names assistive technology reads. `label` on `Button` does not change what is drawn (children); it only replaces the name of the accesskit node (`Context::accesskit_node_builder`). A button that is only an icon or `"x"` would otherwise be read as just that text, so pass it. `alt` on `Image` goes to `egui::Image::alt_text`, and is also drawn next to the warning sign when loading fails. Reading aloud on web is waiting on upstream, as in the non-goals in section 1, but these work on native from today.
+
+`Overlay` is an `egui::Area` as an element: a layer of its own, so it takes no
+space in the surrounding layout and draws over everything in the layer under
+it. `anchor` pins it to an edge or a corner of the window (`"bottom-right"`,
+`"top"`, `"center"`; egui's `Align2` order, `"right-bottom"`, is accepted too)
+and `offset` moves it off that corner; `pos` places it by hand and wins over
+`anchor`. `order` picks the egui layer, `constrain` (on by default) keeps it
+inside the window, and `top` lifts it above the other overlays every frame,
+which is what beats egui's rule that the area shown later is on top. It has two
+modes. **Sized** (`w` and/or `h`): the size is known before anything is drawn,
+so the overlay paints a sheet, takes every press that lands on it — a press on
+the sheet reaches nothing underneath — and roots a taffy tree of its own, the
+way the runner roots the app, so a `<View w="100%" h="100%">` inside fills the
+sheet. A percentage is of the window (`Context::content_rect`), an axis that is
+not given is the window's, and the sheet is filled with `fill` or with the
+theme's `panel_fill` (`fill={Color32::TRANSPARENT}` opts out). **Unsized**
+(neither given): the overlay is as big as its children, paints nothing unless
+`fill` is given, and lets every press beside them through. Not drawing an
+`<Overlay>` unmounts its children, as `open={false}` does for a `<Window>`.
+`Frame`'s `shadow` casts the theme's window shadow, and `custom_shadow` casts
+one of your own; `Button`'s `padding` and `corner_radius` are the widget's own,
+so a round floating button needs no escape hatch.
 
 Inside taffy (`Cx::in_taffy()`), `TextEdit` fills its node. Single-line sets `desired_width` to the node width, and `multiline` fills both ways with `ui.add_sized(ui.available_size(), ..)` (`desired_rows` only fits in whole rows, and the remainder spills out of the node). This is because drawing at egui's default 280pt / 4 rows inside a node widened with `grow` or `w` leaves the rest empty. If `desired_width` / `rows` is given explicitly, that wins. `Slider` / `ComboBox` / `Button` do not stretch for now (they stay at `spacing.slider_width` / `spacing.combo_width` / content width respectively).
 

--- a/docs/tasks/layout/plan.md
+++ b/docs/tasks/layout/plan.md
@@ -261,3 +261,511 @@ without it; the gallery is no worse than today in the meantime.
 - Percent `w` / `h` on an overlay are of the window. Of the parent tree's
   root would be another reading; the window is what a floating thing is
   placed in, so the window.
+
+## 9. Implementation plan (2026-09-08)
+
+Sections 1-8 are the design. This section is the order of work, checked
+against the code as it is at `76ac39f` (PR #15) and against egui 0.36.1,
+egui_kittest 0.36.1 and accesskit 0.24.1 as pulled into `Cargo.lock`. Where it
+differs from sections 1-8, this section wins; each difference is called out.
+
+### 9.0 Decisions on the open questions, and what changed from 1-8
+
+| Question | Decision | Why |
+|---|---|---|
+| `Anchor` spellings (8) | CSS-ish is the primary spelling (`"bottom-right"`, `"top"`, `"center"`); egui's `Align2` order is accepted too (`"right-bottom"`, `"center-top"`) | The rest of the props follow CSS. Aliases need a hand-written `parse`, so `Anchor` is not a `str_enum!` |
+| Where `Anchor` and `Order` live (1) | `crates/egui-react-elements/src/containers.rs`, next to `Side`, not `egui_react::layout` | They are egui container concepts, not layout attributes; `#[prop(into)]` only needs `From<&str>`, which `Side` already shows |
+| Default `fill` of a sized `<Overlay>` (8) | `visuals.panel_fill`; `fill={Color32::TRANSPARENT}` opts out. Unsized: nothing unless `fill` is given | A sheet is always painted; a corner button never is. The gallery then reads `cx.ctx()` for `content_rect()` only |
+| Percent `w` / `h` (8) | Of `ctx.content_rect()`. In sized mode an axis that is not given is the window's on that axis | A sheet is measured against the window. A content-sized floating thing is the unsized mode (put a `<View w=..>` inside) |
+| `pos` and `anchor` both given | `pos` wins; neither means egui's default (top-left, as `<Window>` without `default_pos`) | egui itself treats both as an error |
+| `root_style()` (1) | Moves to `egui_react::layout::root_style`; `egui_react_app::root_style` becomes a re-export | The elements crate cannot depend on the app crate, and the two must not drift |
+| Hidden leaves and accesskit (4) | egui registers an accesskit node for every widget in an invisible `Ui` (the limit 5.8 already documents for `<Suspense>`), so a hidden leaf cannot keep its widgets out of the tree. Instead the leaf's `Ui` gets a node of its own, role `GenericContainer`, marked `hidden`, and every widget under it hangs from that node. `accesskit_consumer::common_filter` excludes a hidden node *with its subtree* — native adapters and `accesskit-web` (`crates/accesskit-web/src/filters.rs`) both use it — so assistive technology never sees them. A hidden `<Text>` registers nothing at all | kittest does not filter hidden nodes, so a test about a hidden *widget* checks the widget's accesskit parent `is_hidden()` and that a press does nothing; a test about a hidden `<Text>` checks `query_by_label` is `None` |
+| Trees under a hidden leaf (4) | A `<ScrollArea>` under a hidden `<View>` opens a tree of its own over an invisible `Ui`; that tree starts hidden too, through a counter in the `Store` that `Cx::leaf` holds while a hidden leaf runs. `Cx::is_hidden()` reads it on every surface | showcase's `"no notes"` sits in a `<ScrollArea>`; the gallery test asserts it is gone while the code is up |
+| The code pane (4, 5) | Only the example is kept mounted under `display="none"`; `<Code>` stays conditional | Its state is a galley cache that rebuilds in a few ms, and its `hyperlink_to` would stay in the tree kittest queries (`source on GitHub` is asserted absent) |
+| `<Window>`, `<Overlay>`, `<Panel>`, `<CentralPanel>` under a hidden view | Not drawn (`if cx.is_hidden() { return; }`); their children unmount as when `open` is false | An `Area` is a layer of its own and a docked panel draws into the tree's root `Ui`; neither is reached by an invisible leaf `Ui` |
+
+Two facts the tests rely on, from the egui 0.36.1 source:
+
+- `AnimationManager::animate_bool`: the first call inserts the id and returns
+  the target as it is; each later call moves by at most `stable_dt /
+  animation_time`, so with `step_dt` 0.05 and `time` 0.5 the value reaches 1 in
+  ten steps; `animation_time == 0` divides by zero, the result is not finite,
+  and the target is returned — 1 on the first step that sees `on = true`.
+  `Context` asks for a repaint while `0 < v < 1`.
+- `Area::show`: the first frame of an area is egui's own sizing pass
+  (`sizing_pass = state.is_none()`), invisible and not interactable. Tests
+  `harness.run()` before they press anything on or under an overlay.
+
+### 9.1 Step 1: `use_animate`
+
+`crates/egui-react/src/hooks.rs`:
+
+```rust
+/// egui's `animate_bool_with_time_and_easing` behind a hook: 0 while `on` is
+/// false, 1 while it is true, and in between for `time` seconds after `on`
+/// flips, eased with `cubic_out`.
+///
+/// egui's `AnimationManager` owns the value and requests the repaints while it
+/// moves, so nothing is stored in the `Store` and the repaint policy (5.6) is
+/// untouched. No `Store` slot means no sweep either: the animation of a
+/// component that stops being drawn stays in egui's memory at its last value,
+/// which is what `animate_bool` does for everyone.
+#[track_caller]
+pub fn use_animate(cx: &mut Cx<'_, '_>, on: bool, time: f32) -> f32 {
+    use_animate_with(cx, on, time, egui::emath::easing::cubic_out)
+}
+
+/// [`use_animate`] with an easing of the caller's choosing (`egui::emath::easing`).
+#[track_caller]
+pub fn use_animate_with(cx: &mut Cx<'_, '_>, on: bool, time: f32, easing: fn(f32) -> f32) -> f32 {
+    let id = cx.scope_id().with(location_key(Location::caller()));
+    cx.ctx().animate_bool_with_time_and_easing(id, on, time, easing)
+}
+```
+
+Both are `#[track_caller]`, so `Location::caller()` in the second is the
+component's call site whichever one it called. Export from `lib.rs` (the
+`pub use hooks::{..}` at the top and the one in `prelude`); update the module
+doc line of `hooks.rs`.
+
+Test `crates/egui-react/tests/animate.rs` (`mod common; use common::run_app;`,
+`Harness::builder().with_step_dt(0.05).build_ui_state(..)`, an
+`Rc<Cell<bool>>` for `on` and an `Rc<Cell<f32>>` the app writes the value to):
+
+- `off_is_zero_and_on_rises_to_one_over_time` (`time` 0.5): one step with
+  `on = false` reads 0.0. Flip `on`; the next step reads `0 < v < 1`. Step up
+  to twelve more times, collecting the values: each is `>=` the previous, the
+  last is exactly 1.0 (`cubic_out(1.0)` is `1 - 0`), and it took at least eight
+  steps to get there. Flip `on` back; after one step `v < 1`, after twelve
+  `v == 0.0` (`1.0 - easing(1.0 - 0.0)` is exactly 0).
+- `zero_time_flips_at_once` (`time` 0.0): 0.0, flip, one step, 1.0.
+
+### 9.2 Step 2: `<Frame shadow>` and `<Button padding corner_radius>`
+
+`containers.rs`, `Frame`: two props, `#[prop(default)] shadow: bool` and
+`custom_shadow: Option<egui::Shadow>`, and `#[allow(clippy::too_many_arguments)]`
+(nine parameters). Inside the leaf:
+
+```rust
+if let Some(shadow) = custom_shadow {
+    frame = frame.shadow(shadow);
+} else if shadow {
+    frame = frame.shadow(ui.visuals().window_shadow);
+}
+```
+
+`widgets.rs`, `Button`: `padding: Option<(f32, f32)>` and
+`corner_radius: Option<f32>`, same allow. Inside the leaf, before the widget:
+
+```rust
+if let Some((x, y)) = padding {
+    // The leaf's own `Ui` in a tree, the scope's `push_id` child outside:
+    // `spacing_mut` copies the style, so nothing leaks past this element.
+    ui.spacing_mut().button_padding = egui::vec2(x, y);
+}
+let mut button = egui::Button::new(children).wrap_mode(egui::TextWrapMode::Extend);
+if let Some(radius) = corner_radius {
+    button = button.corner_radius(radius); // `CornerRadius: From<f32>`
+}
+```
+
+Tests, in the existing files:
+
+- `tests/widgets.rs`, `padding_widens_the_button`: `<Button label="plain">"x"</Button>`
+  and `<Button label="padded" padding={(16.0, 12.0)}>"x"</Button>` in a
+  `<View direction="column">`. With `base = harness.ctx.style().spacing.button_padding`
+  (`vec2(4.0, 1.0)` by default), `padded.width() - plain.width()` is within 1
+  point of `2.0 * (16.0 - base.x)` and the height difference within 1 point of
+  `2.0 * (12.0 - base.y)`; the leaf measure is `ceil`ed, hence the tolerance.
+  A `corner_radius={24.0}` button in the same tree still clicks.
+- `tests/containers.rs`, `a_shadowed_frame_lays_out_like_a_plain_one`: a
+  plain `<Frame inner_margin={4.0}>` and a `<Frame shadow inner_margin={4.0}>`
+  in a column, each holding a `<Label>`; the two labels have the same size and
+  the same `left`, and the second is below the first. A third frame with
+  `custom_shadow={egui::Shadow::NONE}` compiles and hosts a counter that keeps
+  its state.
+
+### 9.3 Step 3: `root_style` into core
+
+`crates/egui-react/src/layout.rs` gets `pub fn root_style() -> taffy::Style`
+with the doc comment that is on `egui_react_app::root_style` today (the
+`min_h` history included). `crates/egui-react-app/src/lib.rs` keeps the name:
+`pub use egui_react::layout::root_style;` with a one-line doc pointing at the
+core one. `use egui_react::layout::{ContainerStyle, ItemStyle}` in the app
+crate becomes unused and goes. Everything that imports
+`egui_react_app::root_style` (the gallery, `examples/*/tests`,
+`crates/egui-react-app/tests/root_fill.rs`) keeps compiling; the three
+`fn root_style()` copies in `crates/egui-react/tests/engine_*.rs` are left
+alone (they are the tests' own minimal styles).
+
+This is a commit of its own only if step 4 is not the same day; otherwise it
+is the first hunk of step 4.
+
+### 9.4 Step 4: `<Overlay>`
+
+#### Enums (`containers.rs`, after `Side`)
+
+```rust
+/// Where an [`Overlay`] is pinned to the window.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Anchor { #[default] TopLeft, Top, TopRight, Left, Center, Right, BottomLeft, Bottom, BottomRight }
+```
+
+`Anchor::parse` takes both spellings: `"top-left" | "left-top"`,
+`"top" | "center-top"`, `"top-right" | "right-top"`, `"left" | "left-center"`,
+`"center" | "center-center"`, `"right" | "right-center"`,
+`"bottom-left" | "left-bottom"`, `"bottom" | "center-bottom"`,
+`"bottom-right" | "right-bottom"`. `From<&str>` panics on anything else,
+naming the CSS spellings, as `Side` does. `Anchor::to_align2` maps onto
+`LEFT_TOP .. RIGHT_BOTTOM`.
+
+```rust
+/// Which layer an [`Overlay`] is drawn in: `egui::Order`, with `From<&str>`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Order { Background, Middle, #[default] Foreground, Tooltip }
+```
+
+`"background" | "middle" | "foreground" | "tooltip"`; `Order::to_egui`.
+Both go into `prelude`.
+
+#### The element
+
+```rust
+#[component]
+#[allow(clippy::too_many_arguments)]
+pub fn Overlay(
+    cx: &mut Cx,
+    #[prop(default)] style: ItemStyle,   // only `w` / `h` are read
+    #[prop(into)] anchor: Option<Anchor>,
+    #[prop(default)] offset: (f32, f32),
+    pos: Option<egui::Pos2>,
+    #[prop(default, into)] order: Order,
+    #[prop(default = true)] constrain: bool,
+    #[prop(default)] top: bool,
+    fill: Option<egui::Color32>,
+    children: impl View,
+) {
+    let (store, scope) = (cx.store, cx.scope_id());
+    let layout = cx.layout_id();
+    let ctx = cx.ctx().clone();
+    let screen = ctx.content_rect();
+
+    // Sized: the sheet is known before anything is drawn, so it can take the
+    // presses and root a tree. `Px` as is, `Percent` of the window, an axis
+    // that is not given is the window's.
+    let sized = style.w.is_some() || style.h.is_some();
+    let resolve = |len: Option<Length>, full: f32| match len {
+        Some(Length::Px(v)) => v,
+        Some(Length::Percent(p)) => p * full,
+        Some(Length::Auto) | None => full,
+    };
+    let sheet_size = egui::vec2(resolve(style.w, screen.width()), resolve(style.h, screen.height()));
+
+    let mut area = egui::Area::new(scope)
+        .order(order.to_egui())
+        .constrain(constrain)
+        .movable(false); // `Area::new` is movable by default; `anchor` / `fixed_pos` clear it, a bare overlay has to
+    match (pos, anchor) {
+        (Some(pos), _) => area = area.fixed_pos(pos),
+        (None, Some(anchor)) => area = area.anchor(anchor.to_align2(), egui::vec2(offset.0, offset.1)),
+        (None, None) => {}
+    }
+    if sized {
+        area = area.default_size(sheet_size); // right on the first frame, before the sheet has been allocated once
+    }
+    if top {
+        // Every frame: egui keeps the areas of an `Order` in first-shown
+        // order and a click brings one forward.
+        ctx.move_to_top(area.layer());
+    }
+    area.show(&ctx, move |ui| {
+        if sized {
+            let sheet = egui::Rect::from_min_size(ui.max_rect().min, sheet_size);
+            let fill = fill.unwrap_or_else(|| ui.visuals().panel_fill);
+            ui.painter().rect_filled(sheet, 0.0, fill);
+            // The whole sheet, before the children: it makes the area the
+            // sheet's size (that is what stops a press reaching the layer
+            // beneath) and a later widget in the same layer is on top of it,
+            // so the children's buttons still get theirs.
+            ui.allocate_rect(sheet, egui::Sense::click());
+            let mut ui = ui.new_child(egui::UiBuilder::new().max_rect(sheet));
+            let mut cx = Cx::new(store, &mut ui, scope);
+            cx.with_layout_id(layout, |cx| {
+                cx.root_container(scope.with("overlay"), root_style(), |cx| children.show(cx));
+            });
+        } else {
+            // The background is painted after the children, into a slot
+            // claimed before them, because the area's rect is what they drew.
+            let background = fill.map(|_| ui.painter().add(egui::Shape::Noop));
+            let mut cx = Cx::new(store, ui, scope);
+            cx.with_layout_id(layout, |cx| children.show(cx));
+            if let (Some(idx), Some(fill)) = (background, fill) {
+                ui.painter().set(idx, egui::Shape::rect_filled(ui.min_rect(), 0.0, fill));
+            }
+        }
+    });
+}
+```
+
+`use egui_react::layout::{ItemStyle, Length, root_style};` at the top of the
+file. Like `<Window>`, no `cx.leaf`: an area takes no room from the parent,
+and in tree mode the component is ids only. Not drawing an `<Overlay>` (the
+`if open { .. }` pattern) unmounts its children through the ordinary sweep;
+egui keeps the `AreaState` (last position and size), which is fine. Step 6
+adds `if cx.is_hidden() { return; }` at the top. Doc comment: the table in
+section 0 in prose, the two modes, and that presses on the sheet go nowhere.
+
+#### Tests: `crates/egui-react-elements/tests/overlay.rs`
+
+`mod common; use common::run_app;`, a `Harness::builder().with_size(vec2(400.0, 800.0))`
+harness; `Counter` as in `tests/containers.rs`. Every test does
+`harness.run()` before it reads a rect or presses (9.0, the area's first frame).
+
+1. `anchored_bottom_right_stays_in_the_corner`: a `<View direction="column" w="100%">`
+   holding a `<Label>` and a `<View h={2000.0}/>`, and
+   `<Overlay anchor="bottom-right" offset={(-16.0, -16.0)}><Button label="fab">"+"</Button></Overlay>`.
+   `fab.right() <= 400 - 15`, `fab.bottom() <= 800 - 15`, `fab.left() > 200`,
+   `fab.top() > 400`.
+2. `a_sized_overlay_takes_the_presses`: an `Rc<Cell<u32>>` counted by
+   `<Button label="under" on_click=..>` in the tree, and
+   `<Overlay w="100%" h="100%"><Label>"sheet"</Label></Overlay>` after it.
+   `get_by_label("under").click()` (kittest presses at the node's centre, the
+   sheet's layer is on top there), `run()`, the count is 0. The same app with
+   the overlay switched off through an `Rc<Cell<bool>>`: the count is 1.
+3. `a_sized_overlay_roots_a_tree_that_fills_the_sheet`:
+   `<Overlay w="100%" h="100%"><View direction="column" w="100%" h="100%" justify="space-between"><Label>"head"</Label><Label>"foot"</Label></View></Overlay>`;
+   `head.top() < 30`, `foot.bottom() > 770`.
+4. `an_overlay_not_drawn_unmounts_its_children`: `if show.get() { <Overlay anchor="center"><Counter name="sheet"/></Overlay> }`.
+   `sheet: 0`; press `sheet +`; `sheet: 1`; `harness.state().len() == 1`;
+   `show = false`, run: no `sheet: 1`, `state().len() == 0`; `show = true`,
+   run: `sheet: 0`.
+5. `top_keeps_an_overlay_above_a_later_one`: two overlays, both
+   `pos={egui::pos2(50.0, 50.0)} w={200.0} h={200.0}`, each with one button at
+   the same place (`first` / `second`) writing into an `Rc<Cell<&str>>`. With
+   `top` on the first, `get_by_label("first").click()` records `"first"`.
+   Without `top` (a second harness) the same press records `"second"`: the
+   later area is above by egui's own rule, which is what `top` overrides.
+
+### 9.5 Step 5: the gallery on top of 1-4
+
+`examples/gallery/src/lib.rs`:
+
+- `PaneToggle` becomes the `rsx!` in section 5. `on_click={|| on_toggle.emit(next)}`.
+- `Menu`: `let down = use_animate(cx, open, MENU_TIME); if down <= 0.0 { return; }`,
+  `let screen = cx.ctx().content_rect();`, then the `rsx!` in section 5 with
+  `<Overlay pos={egui::pos2(screen.left(), top)} constrain={false} top w="100%" h="100%">`
+  and the column `p={8}` (was `sheet.shrink(8.0)`). No `fill`: the sized
+  default is `panel_fill`.
+- `use egui_react_app::root_style;` goes. The doc comments of `PaneToggle`
+  and `Menu` are rewritten: they name `egui::Area` today, and the done
+  criterion is a `grep`, comments included.
+- The module doc (lines 1-13) stays true and stays.
+
+After this commit `grep -c "egui::Area\|Cx::new" examples/gallery/src/lib.rs`
+prints 0 and `cargo test -p gallery` passes unchanged.
+
+### 9.6 Step 6: `display="none"` on both paths
+
+#### `Store` (`store.rs`)
+
+```rust
+/// How many hidden leaves are being drawn right now (nested leaves count up).
+hidden: Cell<u32>,
+```
+
+`begin_pass` sets it to 0 (a panic inside a leaf must not leave it raised).
+`pub(crate) fn enter_hidden(&self) -> HiddenGuard<'_>` increments and returns
+a guard that decrements on drop; `pub fn in_hidden(&self) -> bool`.
+
+#### `Cx` (`cx.rs`)
+
+```rust
+/// Is this `Cx` inside a `display="none"` subtree?
+///
+/// True inside a hidden `<View>` on either layout path, and inside anything
+/// a leaf of one opens (a `<ScrollArea>`'s children, a tree of their own).
+pub fn is_hidden(&self) -> bool {
+    self.store.in_hidden() || match &self.surface {
+        Surface::Ui(_) => false,
+        Surface::Tree(tree) => tree.hidden(),
+        Surface::Lite(lite) => lite.hidden(),
+    }
+}
+```
+
+- `leaf` and `leaf_fill`: `let _hidden = self.is_hidden().then(|| store.enter_hidden());`
+  around the surface call, so a tree opened inside the leaf starts hidden.
+- `text`, `Surface::Ui` arm: if `self.is_hidden()`, no `Label`:
+  `let id = ui.next_auto_id(); ui.skip_ahead_auto_ids(1); ui.interact(Rect::NOTHING, id, Sense::hover())`.
+- `container_taffy`: `engine::show` reads `store.in_hidden()` itself;
+  `lite::show` gets a `hidden: bool` argument.
+
+#### Taffy path (`engine/mod.rs`)
+
+`TreeCx` gets `hidden: bool` (copied by `reborrow`, read by `pub(crate) fn hidden`);
+`show` starts the root at `store.in_hidden()`.
+
+- `container`: `let hidden = self.hidden || style.display == taffy::Display::None;`
+  before the style is handed to `add_child_node`; the child `TreeCx` carries
+  it. The node is still added and `f` still runs: keys and child indices stay
+  stable (a show after a hide is not a "created" pass) and the components
+  inside keep their hooks.
+- `leaf`: `if first_frame || self.hidden { builder = builder.sizing_pass().invisible(); }`;
+  `created_this_frame` is set only when `first_frame && !self.hidden` (a
+  hidden leaf's draw is not a measurement anyone waits for). After `new_child`
+  and before `f`, when hidden:
+
+  ```rust
+  // Every widget `f` registers hangs from the `Ui`'s own id
+  // (`Ui::interact` -> `register_accesskit_parent`), so one hidden node
+  // here hides the whole subtree from assistive technology:
+  // `accesskit_consumer::common_filter` excludes a hidden node with
+  // everything under it. egui registers the widgets regardless of
+  // visibility (5.8), so this is the one way to keep them out.
+  ui.ctx().accesskit_node_builder(ui.unique_id(), |node| {
+      node.set_role(egui::accesskit::Role::GenericContainer);
+      node.set_hidden();
+  });
+  ```
+
+  `set_measure` is skipped when hidden (taffy lays a `Display::None`
+  subtree out at zero whatever the measure says; the old measure stays on the
+  node for the show).
+- `text`: when hidden, `set_text` as usual (the galley cache and the node
+  shape survive), then `return self.root_ui.interact(Rect::NOTHING, scope.with(index), Sense::hover());`
+  — a widget rect nothing can hit, no `WidgetInfo` (so no accesskit node),
+  no `LabelSelectionState`, no `Noop` shape, no `PendingText`. `paint_texts`
+  needs no change.
+- `finish`: nothing changes. The frame a subtree is hidden or shown is a
+  "moved" pass (real rects to zero, or back), which is one discard, and the
+  leaves' visible draw at a zero rect on the show frame is inside that
+  discarded pass.
+
+#### Lite path (`engine/lite.rs`)
+
+`LiteCx` gets the same `hidden: bool` and the same three changes:
+`container` (`Display::None` is already in the subset, 2073), `leaf` (the
+builder, the accesskit node, no `created`, no measure write), `text` (push the
+text and the node, then the `Rect::NOTHING` response). `hide()` and the
+`compute` short-circuit stay as they are.
+
+#### Elements
+
+`Window`, `Overlay`, `Panel`, `CentralPanel`: `if cx.is_hidden() { return; }`
+first thing, with a doc line each: an `Area` is a layer of its own and a
+docked panel draws into the tree's root `Ui`, so an invisible leaf `Ui` does
+not reach them; their children unmount as when `open` is false.
+
+#### Tests
+
+`crates/egui-react/tests/hidden.rs` (core APIs only: `cx.container`,
+`cx.leaf`, `cx.text`, `use_state`, as `taffy_cx.rs` does; an
+`Rc<Cell<bool>>` `shown`). The tree: a row with `gap` 8 holding leaf `a`
+(a button), a container whose `display` is `"flex"` or `"none"` by `shown`,
+and leaf `b`. Inside the container, under `cx.scope`s: a counter (`use_state`,
+a `hidden +` button leaf, a `count: N` text), a `hidden text` text, and a
+leaf that opens a tree of its own (`Cx::new` over the leaf's `Ui`, then
+`cx.container`) with a `nested text` text in it.
+
+- `a_hidden_view_takes_no_space_and_reports_no_text`: shown, run: `count: 0`,
+  `hidden text` and `nested text` are found. Hidden, run twice: none of the
+  three is; `b.left()` is within 1 point of `a.right() + 8`; `hidden +` is in
+  kittest's tree and `get_by_label("hidden +").accesskit_node().parent()` is
+  `is_hidden()`.
+- `state_survives_a_hide_and_a_show`: shown, press `hidden +`, `count: 1`;
+  hidden, run twice, `harness.state().len()` is what it was (one slot); press
+  where `hidden +` reports itself (nothing happens); shown, run: `count: 1`.
+- `crates/egui-react/tests/lite_parity.rs`: a corpus case `hidden_in_row`,
+  the same row shape (leaf, hidden container with a leaf and a text, leaf).
+  The harness already draws it on both paths and compares every rect; hidden
+  leaves report a zero rect at the row's corner and hidden texts
+  `Rect::NOTHING` on both.
+
+### 9.7 Step 7: the gallery keeps the example, and the docs
+
+`App`, compact branch:
+
+```rust
+<View direction="column" grow={1.0} min_h={0.0} gap={4}>
+    <Text strong wrap>{current.summary}</Text>
+    // Hidden, not unmounted, while the code is up: the example keeps
+    // running (a clock keeps time, a todo keeps its draft), which is what
+    // a tab is expected to do. The `key` still sweeps it on a switch.
+    <View
+        key={current.name}
+        display={if showing == Pane::Example { "flex" } else { "none" }}
+        direction="column"
+        grow={1.0}
+        min_h={0.0}
+    >
+        <Running name={current.name} plain={showing_plain}/>
+    </View>
+    if showing == Pane::Code {
+        <Code w="100%" grow={1.0} min_h={0.0} meta={*current} plain={showing_plain} on_pick={..}/>
+    }
+</View>
+```
+
+`examples/gallery/tests/gallery.rs`: the assertions stay; the comment in
+`a_phone_shows_one_pane_at_a_time` ("the example is gone with its hooks") is
+rewritten. One test is added, `the_example_keeps_its_state_across_a_trip_to_the_code_pane`:
+`<App start="counter"/>` on the phone harness, press `+` twice (`2` is
+shown), `show code`, `show example`, `2` is still shown and `0` is not.
+
+Docs:
+
+- ARCHITECTURE 4: a row for `use_animate(cx, on, time) -> f32` (and
+  `use_animate_with`): egui's `AnimationManager` owns the value, no slot, no
+  sweep.
+- ARCHITECTURE 6, elements table: `Overlay` in Containers with its props and
+  the two modes; `Frame` gains `shadow` / `custom_shadow`; `Button` gains
+  `padding` / `corner_radius`.
+- ARCHITECTURE 6, Layout: a bullet for `display="none"` — zero size on both
+  paths, components keep running, leaves draw into an invisible sizing `Ui`
+  under a hidden accesskit node, a `<Text>` registers nothing, `Cx::is_hidden`,
+  what is not drawn under it. A sentence in 5.8 pointing here for the
+  accesskit limit it already names.
+- ARCHITECTURE 3.1: `Cx::is_hidden` in the list of what `Cx` answers.
+- `docs/tasks/layout/task.md`: a `## Result` table over the done criteria,
+  as `docs/tasks/code-pane/task.md` has.
+
+### 9.8 Order, and what every commit passes
+
+One PR, one commit per step (3 folds into 4):
+
+1. `use_animate` and `tests/animate.rs`.
+2. `<Frame shadow>`, `<Button padding corner_radius>`, their tests.
+3. + 4. `root_style` into core; `Anchor`, `Order`, `<Overlay>`, `tests/overlay.rs`.
+5. Gallery `PaneToggle` and `Menu`; the `grep` is 0.
+6. `display="none"`: `Store`, `Cx::is_hidden`, both engines, the four
+   elements, `tests/hidden.rs`, the parity case.
+7. Gallery keeps the example; the new gallery test; ARCHITECTURE; the result
+   table.
+
+Before each commit, what CI runs (`.github/workflows/ci.yml`):
+
+```sh
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo check --workspace --target wasm32-unknown-unknown
+```
+
+plus, for 5 and 7, `grep -c "egui::Area\|Cx::new" examples/gallery/src/lib.rs`.
+The snapshot tests (`--features snapshot`) need a GPU and are not run here;
+the phone layout has no snapshot today, and the wide layout does not change.
+
+### 9.9 If something in 6 does not hold
+
+- If a widget under a hidden leaf still reaches kittest's `query_by_label`
+  in a way a gallery assertion notices, the assertion names a `<Text>` or the
+  test is wrong about what it asserts; `<Text>` registers nothing under
+  `hidden`, on both paths and in `Ui` mode. Check `Cx::is_hidden` is true on
+  the surface the text was drawn from before touching the test.
+- If taffy does not zero a hidden node's descendants (`compute_hidden_layout`
+  in 0.9 does), the `content_rect` a hidden leaf's `Ui` is built from is the
+  stale one; the leaf is invisible either way, so only the parity case would
+  see it, and `hide()` on the lite side would then need a taffy-side twin.
+- If step 6 grows past this (the `leaf` signature, `paint_texts`), it ships
+  as a PR of its own after 1-5, as section 7 already allows; the gallery is no
+  worse than today in between, and `<Overlay>`'s `is_hidden` line goes in with it.

--- a/docs/tasks/layout/task.md
+++ b/docs/tasks/layout/task.md
@@ -1,5 +1,28 @@
 # Task: overlays without the escape hatch
 
+## Result (2026-09-07)
+
+Every step done, in seven commits; the order is in [plan.md](plan.md) 9.8.
+
+| Done criterion | Status |
+|---|---|
+| `<Overlay anchor="bottom-right">` reports a rect in the window's bottom-right quarter whatever the tree draws | **Pass**, by test (`overlay.rs`, `anchored_bottom_right_stays_in_the_corner`) |
+| An overlay with `w="100%" h="100%"` covers the window, and a press on a button under it does not reach the button | **Pass**, by test (`a_sized_overlay_takes_the_presses`; the same app without the sheet counts the press) |
+| Children of an overlay that is not drawn are unmounted | **Pass**, by test (`an_overlay_not_drawn_unmounts_its_children`; the store is back to zero slots) |
+| `use_animate` goes from 0 to 1 over `time` seconds of steps, and is 1 at once when `time` is 0 | **Pass**, by test (`animate.rs`; ten steps of 0.05 s for `time` 0.5) |
+| A `<View display="none">` has zero size, its `<Text>` is not in the accesskit tree, and a `use_state` inside keeps its value | **Pass**, by test (`hidden.rs`), and both layout paths agree (`lite_parity.rs`, `hidden_in_row`) |
+| `cargo test -p gallery` passes unchanged, and `grep -c "egui::Area\|Cx::new" examples/gallery/src/lib.rs` is 0 | **Pass.** The grep is 0; the gallery tests are unchanged bar one comment, and one test was added |
+| The gallery on a phone looks and moves as it did at the end of PR #15, example state included | **Pass by test** (`the_example_keeps_its_state_across_a_trip_to_the_code_pane`). By hand on a phone: not checked here |
+
+Two things came out different from the plan, both small:
+
+- A hidden `<Text>` registers `Rect::NOTHING`, and the parity test translates
+  every rect by the row's origin, which turns that into NaN — never equal to
+  itself. The test now counts two rects that are both nothing as the same
+  answer.
+- `<Button padding>` is compared against `style.spacing.button_padding`, read
+  through `Context::global_style()`: egui 0.36 has no `Context::style()`.
+
 ## Background
 
 The gallery's compact layout (PR #15, `examples/gallery/src/lib.rs`) puts two

--- a/docs/tasks/paint-style/task.md
+++ b/docs/tasks/paint-style/task.md
@@ -1,0 +1,121 @@
+# Task: one paint style for every element
+
+## Background
+
+Every element takes the same `style: ItemStyle` for layout (`w` `h` `min_*`
+`max_*` `grow` `shrink` `basis` `align_self` `m*` `p*`), and `<View>` adds a
+`ContainerStyle` on top. That is the whole shared vocabulary. Everything about
+how a box *looks* is a prop of one element or another, and which props exist
+is whatever the egui builder underneath happens to have:
+
+| Look | Who has it | Spelled as |
+|---|---|---|
+| Background | `Frame`, `Overlay` | `fill: Option<Color32>` |
+| Border | `Frame` only | `stroke: Option<Stroke>` |
+| Corner radius | `Frame`, `Button` | `corner_radius: Option<f32>` (`Frame` casts it to `u8`) |
+| Shadow | `Frame` only | `shadow: bool` + `custom_shadow: Option<Shadow>` (PR #16) |
+| Padding | `Frame` (`inner_margin: f32`), `Button` (`padding: (f32, f32)`) | Two names, two types, and neither is `ItemStyle::p`, which is the layout padding taffy already resolves |
+
+So a `<View>` cannot have a background, a `<Button>` cannot have a border, a
+`<Text>` cannot cast a shadow, and the only way to get a painted box is to
+wrap the thing in a `<Frame>`. Every example does that (`board`, `custom-hook`,
+`gallery`, `patch`, `shell`, `theme`, eighteen `inner_margin` / `padding`
+sites between them), and each `<Frame>` is one more leaf `Ui` between the tree
+and the widget.
+
+The engine already knows the rect of every node before the widget draws: a
+leaf gets `content_rect(layout)`, its box minus taffy's padding and border, and
+a container gets its box too. `<Overlay>` in sized mode paints its sheet from
+exactly that knowledge (`rect_filled` on the rect, then the children). Nothing
+stops the engine from doing the same for every node, on both paths.
+
+## Goal
+
+A box looks the same way it lays out: with props that every element takes.
+`<View bg=.. border=.. radius=.. shadow>` paints, `<Button p={8} radius={24.0} shadow>`
+is the gallery's floating button without a `<Frame>` around it, and
+`ItemStyle::p` is the one padding.
+
+## Scope
+
+### In scope
+
+- `PaintStyle` (`egui-react`, `layout.rs` or a `paint.rs` next to it): `bg`
+  (`Color32`), `border` (`Stroke`), `radius` (`f32`, one value for now),
+  `shadow` (`bool`, the theme's window shadow) and `custom_shadow`
+  (`egui::Shadow`), `opacity` (`f32`, through `Ui::multiply_opacity`).
+  Builder methods and `Default`, as `ItemStyle`. Every element that takes
+  `style: ItemStyle` takes `paint: PaintStyle` the same way, through
+  `#[component]`, so `bg=..` on any element is the same prop.
+- The engine paints it, on the taffy path and the lite path alike: the
+  shadow, then the background, on the node's border box (not the content
+  rect), before the node's children or widget draw; the border after them.
+  A shape slot claimed before the children (`Painter::add(Shape::Noop)` then
+  `set`, as `<Overlay>` does unsized) where the rect is not known until they
+  have drawn. Hidden nodes (`display="none"`, PR #16) paint nothing.
+- `p` on a leaf means what it means on a container: the widget draws inside
+  the padding, and the background covers it. `Button::padding` and
+  `Frame::inner_margin` go; `Button::corner_radius` becomes `radius`.
+- A widget that paints a box of its own (`Button`, `TextEdit`, `ComboBox`)
+  hands that box over when `bg` or `border` is given: `Button::fill` /
+  `stroke` to transparent / none, `TextEdit::frame(false)`, so the two boxes
+  do not stack. Hover and press colours stay the widget's; `bg` is the
+  resting colour.
+- `<Frame>` stays as the escape hatch for `egui::Frame` itself (a painted
+  frame around egui-native children in `Ui` mode). Inside a tree it is a
+  `<View>` with paint, and the doc says so.
+- The examples on top of it: no `<Frame>` inside a tree, no `inner_margin`.
+  `cargo test --workspace` passes unchanged (the tests query labels and
+  rects; a background does not move a rect).
+- ARCHITECTURE: `PaintStyle` next to `ItemStyle` in section 6, the paint
+  order, and the elements table without `fill` / `stroke` / `inner_margin` /
+  `padding` per element.
+
+### Out of scope
+
+- Per-corner radii, per-side borders, gradients, background images. When
+  someone asks; the struct can grow fields without moving anything.
+- Hover / pressed / focused styling (`bg` that changes with the response).
+  That needs the response before the paint, which is the wrong order for a
+  background; a widget's own visuals do it today and keep doing it.
+- Theming (`use_theme`, style tokens). A `PaintStyle` is plain values; where
+  they come from is a separate task.
+- `Overlay::fill`. It is the sheet's colour and already the sized default;
+  it can become `bg` when the rest lands, on its own commit.
+
+## Deliverables
+
+- `crates/egui-react/src/layout.rs` (or `paint.rs`): `PaintStyle`,
+  exported from `lib.rs` and `prelude`.
+- `crates/egui-react/src/engine/mod.rs` and `engine/lite.rs`: paint on
+  `container` and `leaf`; `Cx::leaf` / `leaf_fill` / `container` take the
+  paint. A corpus case in `tests/lite_parity.rs` so both paths agree on the
+  rects a painted node reports.
+- `crates/egui-react/tests/paint.rs`: kittest over the core APIs.
+- `crates/egui-react-elements`: every element takes `paint`; `Button`,
+  `TextEdit`, `ComboBox` hand their box over; `Frame` re-documented;
+  `Button::padding` / `corner_radius` and `Frame::inner_margin` /
+  `fill` / `stroke` / `corner_radius` / `shadow` / `custom_shadow` removed.
+- The six examples without `<Frame>` in a tree.
+- ARCHITECTURE section 6.
+
+Details and the order of work go in `plan.md`, which settles at least:
+where `PaintStyle` lives; how a border of width `n` relates to taffy's
+`border` (the layout has to reserve it, or the stroke is drawn over the
+content); what `radius` does to a shadow (egui's `Shadow::as_shape` takes a
+corner radius); and whether `#[component]` merges `paint` into `style` or
+keeps two structs.
+
+## Done criteria
+
+- kittest: a `<View bg={RED} p={8}>` around a `<Label>` reports a rect
+  8 points larger than the label on every side, on both paths; the same
+  with `border={Stroke::new(2.0, ..)}` is 2 points larger again.
+- Snapshot (`--features snapshot`): one image of a `<View>` with `bg`,
+  `border`, `radius` and `shadow`, holding a `<Button>` with `bg` and
+  `radius`; it is the shape the gallery's floating button has today.
+- `<Button p={..} radius={..} shadow bg={..}>` in the gallery's `PaneToggle`,
+  with no `<Frame>`, and `cargo test -p gallery` unchanged.
+- `grep -rn "inner_margin\|padding=" examples/*/src` prints nothing, and no
+  `<Frame` sits inside a `<View>` in the examples.
+- `cargo test --workspace`, clippy and the wasm check pass.

--- a/examples/gallery/src/lib.rs
+++ b/examples/gallery/src/lib.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 mod highlight;
 use egui_react::prelude::*;
-use egui_react_app::root_style;
 use egui_react_elements::prelude::*;
 use example_meta::Meta;
 
@@ -245,39 +244,29 @@ fn Header(cx: &mut Cx, compact: bool, #[event] on_menu: ()) {
 /// The button floating in the bottom-right corner of a compact screen, which
 /// swaps the running example for its code and back.
 ///
-/// An `egui::Area` rather than a node of the tree: it sits over the pane,
-/// where a thumb reaches, and takes no room from it. The label says what a
-/// press does; the glyph is what is drawn.
+/// An `<Overlay>` rather than a node of the tree: it sits over the pane, where
+/// a thumb reaches, and takes no room from it. Unsized, so it is as big as the
+/// button and lets every press beside it through. The label says what a press
+/// does; the glyph is what is drawn.
 #[component]
 fn PaneToggle(cx: &mut Cx, showing: Pane, #[event] on_toggle: Pane) {
-    let ctx = cx.ctx().clone();
     let (glyph, label, next) = match showing {
         Pane::Example => ("</>", "show code", Pane::Code),
         Pane::Code => ("⏵", "show example", Pane::Example),
     };
-    let clicked = egui::Area::new(cx.scope_id().with("pane_toggle"))
-        .order(egui::Order::Foreground)
-        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-16.0, -16.0))
-        .show(&ctx, |ui| {
-            egui::Frame::new()
-                .shadow(ui.visuals().window_shadow)
-                .corner_radius(24.0)
-                .show(ui, |ui| {
-                    ui.spacing_mut().button_padding = egui::vec2(16.0, 12.0);
-                    let button = egui::Button::new(egui::RichText::new(glyph).size(18.0))
-                        .corner_radius(24.0)
-                        .wrap_mode(egui::TextWrapMode::Extend);
-                    let response = ui.add(button);
-                    // The glyph is not a name; see `<Button label>`.
-                    ui.ctx()
-                        .accesskit_node_builder(response.id, |node| node.set_label(label));
-                    response.clicked()
-                })
-                .inner
-        })
-        .inner;
-    if clicked {
-        on_toggle.emit(next);
+    rsx! {
+        <Overlay anchor="bottom-right" offset={(-16.0, -16.0)}>
+            <Frame shadow corner_radius={24.0}>
+                <Button
+                    label={label}
+                    padding={(16.0, 12.0)}
+                    corner_radius={24.0}
+                    on_click={|| on_toggle.emit(next)}
+                >
+                    {egui::RichText::new(glyph).size(18.0)}
+                </Button>
+            </Frame>
+        </Overlay>
     }
 }
 
@@ -286,10 +275,10 @@ fn PaneToggle(cx: &mut Cx, showing: Pane, #[event] on_toggle: Pane) {
 ///
 /// It slides down from the top edge when it opens and back up when it closes,
 /// and it is not drawn at all once it is away. While it is on screen it is an
-/// `egui::Area` in the foreground that spans the window, so the pane beneath
-/// gets no clicks. Inside, the list is laid out by a tree of its own, rooted
-/// the way the runner roots the app, so it fills the sheet and the example
-/// list scrolls in what the header leaves.
+/// `<Overlay>` the size of the window, so the pane beneath gets no clicks.
+/// A sized overlay roots a tree of its own, the way the runner roots the app,
+/// so the list fills the sheet and the example list scrolls in what the header
+/// leaves.
 #[component]
 fn Menu(
     cx: &mut Cx,
@@ -302,66 +291,45 @@ fn Menu(
     #[event] on_clear: (),
     #[event] on_close: (),
 ) {
-    let (store, scope) = (cx.store, cx.scope_id());
-    let ctx = cx.ctx().clone();
     // 0 when the menu is away, 1 when it is down; in between it is moving.
-    let down = ctx.animate_bool_with_time_and_easing(
-        scope.with("slide"),
-        open,
-        MENU_TIME,
-        egui::emath::easing::cubic_out,
-    );
+    let down = use_animate(cx, open, MENU_TIME);
     if down <= 0.0 {
         return;
     }
-    let screen = ctx.content_rect();
+    let screen = cx.ctx().content_rect();
     let top = screen.top() - screen.height() * (1.0 - down);
-    let id = scope.with("menu");
-    // Above the pane toggle and anything else in the foreground, every frame:
-    // egui keeps the areas in the order they were first shown, and a click
-    // brings one to the front.
-    ctx.move_to_top(egui::LayerId::new(egui::Order::Foreground, id));
-    egui::Area::new(id)
-        .order(egui::Order::Foreground)
-        .fixed_pos(egui::pos2(screen.left(), top))
-        // Partly above the window while it slides.
-        .constrain(false)
-        .default_size(screen.size())
-        .show(&ctx, move |ui| {
-            let sheet = egui::Rect::from_min_size(ui.max_rect().min, screen.size());
-            ui.painter()
-                .rect_filled(sheet, 0.0, ui.visuals().panel_fill);
-            // The whole sheet, not just the widgets on it, is what stops a
-            // press from reaching the pane beneath.
-            ui.allocate_rect(sheet, egui::Sense::click());
-            let inner = sheet.shrink(8.0);
-            let mut ui = ui.new_child(egui::UiBuilder::new().max_rect(inner));
-            let mut cx = Cx::new(store, &mut ui, scope);
-            cx.root_container(scope.with("menu_root"), root_style(), |cx| {
-                rsx! {
-                    <View direction="column" gap={8} w="100%" h="100%">
-                        // The same header, with the button that closes the
-                        // menu where the one that opened it was.
-                        <View direction="row" align="center" gap={8} w="100%">
-                            <Text strong size={20.0} grow={1.0}>"egui-react"</Text>
-                            <Button label="close menu" on_click={|| on_close.emit(())}>"×"</Button>
-                        </View>
-                        <List
-                            w="100%"
-                            grow={1.0}
-                            min_h={0.0}
-                            shown={shown}
-                            active={active}
-                            selected={selected}
-                            on_select={|name: &'static str| on_select.emit(name)}
-                            on_tag={|tag: &'static str| on_tag.emit(tag)}
-                            on_clear={|| on_clear.emit(())}
-                        />
-                    </View>
-                }
-                .show(cx);
-            });
-        });
+    rsx! {
+        // `top` keeps the menu above the pane toggle and anything else in the
+        // foreground; `constrain={false}` lets it hang above the window while
+        // it slides. No `fill`: a sized overlay paints `panel_fill` itself.
+        <Overlay
+            pos={egui::pos2(screen.left(), top)}
+            constrain={false}
+            top
+            w="100%"
+            h="100%"
+        >
+            <View direction="column" gap={8} w="100%" h="100%" p={8}>
+                // The same header, with the button that closes the menu where
+                // the one that opened it was.
+                <View direction="row" align="center" gap={8} w="100%">
+                    <Text strong size={20.0} grow={1.0}>"egui-react"</Text>
+                    <Button label="close menu" on_click={|| on_close.emit(())}>"×"</Button>
+                </View>
+                <List
+                    w="100%"
+                    grow={1.0}
+                    min_h={0.0}
+                    shown={shown}
+                    active={active}
+                    selected={selected}
+                    on_select={|name: &'static str| on_select.emit(name)}
+                    on_tag={|tag: &'static str| on_tag.emit(tag)}
+                    on_clear={|| on_clear.emit(())}
+                />
+            </View>
+        </Overlay>
+    }
 }
 
 /// The example list and the tag filter.

--- a/examples/gallery/src/lib.rs
+++ b/examples/gallery/src/lib.rs
@@ -125,26 +125,31 @@ pub fn App(cx: &mut Cx, #[prop(default = EXAMPLES[0].name)] start: &'static str)
                 // One pane, and the summary above it whichever it is.
                 <View direction="column" grow={1.0} min_h={0.0} gap={4}>
                     <Text strong wrap>{current.summary}</Text>
-                    match showing {
-                        // The same `key` as the wide layout: switching
-                        // examples sweeps the previous one's hooks. Switching
-                        // to the code does too, so the example starts over
-                        // when it comes back.
-                        Pane::Example => {
-                            <View key={current.name} direction="column" grow={1.0} min_h={0.0}>
-                                <Running name={current.name} plain={showing_plain}/>
-                            </View>
-                        }
-                        Pane::Code => {
-                            <Code
-                                w="100%"
-                                grow={1.0}
-                                min_h={0.0}
-                                meta={*current}
-                                plain={showing_plain}
-                                on_pick={|pick: bool| *plain = pick}
-                            />
-                        }
+                    // Hidden, not unmounted, while the code is up: the
+                    // example keeps running (a clock keeps time, a todo keeps
+                    // its draft), which is what a tab is expected to do. The
+                    // `key` still sweeps it on a switch.
+                    <View
+                        key={current.name}
+                        display={if showing == Pane::Example { "flex" } else { "none" }}
+                        direction="column"
+                        grow={1.0}
+                        min_h={0.0}
+                    >
+                        <Running name={current.name} plain={showing_plain}/>
+                    </View>
+                    // The code pane stays conditional: its state is a galley
+                    // cache that rebuilds in a few milliseconds, and its
+                    // source link would stay in the accessibility tree.
+                    if showing == Pane::Code {
+                        <Code
+                            w="100%"
+                            grow={1.0}
+                            min_h={0.0}
+                            meta={*current}
+                            plain={showing_plain}
+                            on_pick={|pick: bool| *plain = pick}
+                        />
                     }
                 </View>
                 // Not while the menu is down: it covers the corner the

--- a/examples/gallery/tests/gallery.rs
+++ b/examples/gallery/tests/gallery.rs
@@ -295,8 +295,8 @@ fn a_phone_shows_one_pane_at_a_time() {
     harness.run();
     harness.run();
 
-    // The code pane, the full width of the window, and the example is gone
-    // with its hooks.
+    // The code pane, the full width of the window. The example is hidden, so
+    // nothing it drew is in the tree any more, though it is still running.
     assert!(harness.query_by_label("no notes").is_none());
     let link = harness.get_by_label("source on GitHub").rect();
     assert!(
@@ -318,6 +318,57 @@ fn a_phone_shows_one_pane_at_a_time() {
     harness.run();
     assert!(harness.query_by_label("no notes").is_some());
     assert!(harness.query_by_label("source on GitHub").is_none());
+}
+
+/// A hidden example keeps running, so its state is still there when the code
+/// pane is closed again.
+///
+/// `display="none"` rather than an unmount: what a tab is expected to do.
+#[test]
+fn the_example_keeps_its_state_across_a_trip_to_the_code_pane() {
+    let mut harness = Harness::builder().with_size(PHONE).build_ui_state(
+        |ui, store: &mut Store| {
+            store.begin_pass(ui.ctx());
+            {
+                let store: &Store = store;
+                let mut cx = Cx::new(store, ui, root_id());
+                let view = rsx! { <App start="counter"/> };
+                cx.root_container(root_id(), root_style(), |cx| view.show(cx));
+            }
+            store.end_pass();
+        },
+        Store::new(),
+    );
+    harness.run();
+
+    harness.get_by_label("+").click();
+    harness.run();
+    harness.get_by_label("+").click();
+    harness.run();
+    assert!(
+        harness.query_by_label("2").is_some(),
+        "the count should be 2"
+    );
+
+    harness.get_by_label("show code").click();
+    harness.run();
+    harness.run();
+    assert!(
+        harness.query_by_label("2").is_none(),
+        "the example is hidden"
+    );
+
+    harness.get_by_label("show example").click();
+    harness.run();
+    harness.run();
+    assert!(
+        harness.query_by_label("2").is_some(),
+        "the counter should have kept its state"
+    );
+    assert!(
+        harness.query_by_label("0").is_none(),
+        "the counter should not have started over"
+    );
 }
 
 /// The menu slides down over the page, lists every example and every tag,


### PR DESCRIPTION
## Summary

Implements `docs/tasks/layout/plan.md` section 9 (PR #16): the gallery's two overlays and the hidden example pane are now done with elements and hooks any app can use. `grep -c "egui::Area\|Cx::new" examples/gallery/src/lib.rs` is 0. Re-creates #17 against main (#17 was merged into the plan branch and cannot be reopened). Includes #16.

Also adds the task for the next step: one paint style (`bg` / `border` / `radius` / `shadow`) across every element, instead of per-element props.

## Changes

- Added `use_animate` / `use_animate_with` hooks over egui's `AnimationManager`
- Added `<Overlay>` with `Anchor` and `Order`
  - Sized (`w` / `h`): paints a sheet, takes the presses, roots a taffy tree of its own
  - Unsized: as big as its children, presses beside them go through
- Added `<Frame shadow custom_shadow>` and `<Button padding corner_radius>`
- Implemented `display="none"` on both layout paths
  - Zero box, components keep running and keep their hooks
  - Leaves draw into an invisible sizing `Ui` under a hidden accesskit node; `<Text>` registers nothing
  - `Cx::is_hidden`; `Window` / `Overlay` / `Panel` / `CentralPanel` draw nothing under it
- Changed `root_style` to live in `egui_react::layout`; the app crate re-exports it
- Changed the gallery
  - `PaneToggle` and `Menu` on `<Overlay>`, `<Frame>`, `<Button>` and `use_animate`
  - The example stays mounted under `display="none"` while the code pane is up, so it keeps its state
- Added tests: `animate.rs`, `overlay.rs`, `hidden.rs`, a `lite_parity` case, and one gallery test
- Added ARCHITECTURE entries and the result table in `docs/tasks/layout/task.md`
- Added `docs/tasks/paint-style/task.md`
