### PR TITLE
chore: follow the repo rename in URLs and site base

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,6 @@
 name: Pages
 
-# Publishes the documentation site to https://fand.github.io/egui-react/:
+# Publishes the documentation site to https://fand.github.io/egui-reactor/:
 # the VitePress pages, the `embed` wasm every example page runs in an iframe,
 # and `cargo doc`. `site/build.sh` is what assembles the three; this workflow
 # only installs the toolchains it needs and uploads what it produced.
@@ -71,7 +71,7 @@ jobs:
       # its `base` and trunk as the `--public-url` of the embed, so every
       # generated URL carries the prefix.
       - name: Build the site
-        run: SITE_BASE=/egui-react/ bash site/build.sh
+        run: SITE_BASE=/egui-reactor/ bash site/build.sh
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*", "examples/*"]
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/fand/egui-react"
+repository = "https://github.com/fand/egui-reactor"
 rust-version = "1.95"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 egui-reactor is a Rust library for writing [egui](https://github.com/emilk/egui) applications the way you write React: a JSX-like `rsx!` macro, function components with `#[component]`, and hooks such as `use_state` and `use_effect`. Because egui is immediate mode there is no retained tree and no reconciler, so event handlers run where they are written and can borrow local state with `&mut` — none of the `'static` closures, `Rc<RefCell<_>>` or `.clone()` ceremony that retained-mode Rust UI frameworks require. Flexbox and Grid layout are first-class: `<View>` is a node in a small layout engine of our own, written over [taffy](https://github.com/DioxusLabs/taffy).
 
-The documentation — a guide, a reference and every example running in the browser next to its source — is at [fand.github.io/egui-react](https://fand.github.io/egui-react/).
+The documentation — a guide, a reference and every example running in the browser next to its source — is at [fand.github.io/egui-react](https://fand.github.io/egui-reactor/).
 
 The current design is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); design decisions are in [docs/adr/](docs/adr/).
 
@@ -50,29 +50,29 @@ The hooks, the elements and the layout attributes are listed in [docs/ARCHITECTU
 
 ## Examples
 
-Every example runs in the browser on its own page in the [documentation site](https://fand.github.io/egui-react/), next to its source. Start with `notes`, a small notes app that uses most of the library at once; the rest take one idea each. Some of them also have a version written with plain egui, so you can switch between the two and compare. `cargo run -p gallery` is the native three-column tool — the example list, the running example and its code in one window — and the site is the web version of the same thing, one page per example. Either way the example runs on a canvas, so a screen reader reads it natively but not on the web; the widget names are there in both (`docs/tasks/a11y/`).
+Every example runs in the browser on its own page in the [documentation site](https://fand.github.io/egui-reactor/), next to its source. Start with `notes`, a small notes app that uses most of the library at once; the rest take one idea each. Some of them also have a version written with plain egui, so you can switch between the two and compare. `cargo run -p gallery` is the native three-column tool — the example list, the running example and its code in one window — and the site is the web version of the same thing, one page per example. Either way the example runs on a canvas, so a screen reader reads it natively but not on the web; the widget names are there in both (`docs/tasks/a11y/`).
 
 ![The gallery: example list, the running example, and its source next to it](docs/gallery.png)
 
 | name | what | live | source | plain egui |
 |---|---|---|---|---|
-| `notes` | A notes app: reducer, persistence, context, memo and an editor, together. | [notes](https://fand.github.io/egui-react/examples/notes) | [lib.rs](examples/notes/src/lib.rs) | – |
-| `board` | Cards that keep the title being typed into them while they are dragged between columns. | [board](https://fand.github.io/egui-react/examples/board) | [lib.rs](examples/board/src/lib.rs) | [plain.rs](examples/board/src/plain.rs) |
-| `patch` | A node editor that generates, validates and previews its own WGSL shader. | [patch](https://fand.github.io/egui-react/examples/patch) | [lib.rs](examples/patch/src/lib.rs) | – |
-| `spreadsheet` | Formulas over 26 × 10,000 cells: two memo stages, and a draft that survives scrolling out of view. | [spreadsheet](https://fand.github.io/egui-react/examples/spreadsheet) | [lib.rs](examples/spreadsheet/src/lib.rs) | – |
-| `counter` | One piece of state, three handlers that borrow it in turn. | [counter](https://fand.github.io/egui-react/examples/counter) | [lib.rs](examples/counter/src/lib.rs) | – |
-| `todo` | A reducer drives the list; `use_persisted` keeps it across restarts. | [todo](https://fand.github.io/egui-react/examples/todo) | [lib.rs](examples/todo/src/lib.rs) | [plain.rs](examples/todo/src/plain.rs) |
-| `form` | Every bound widget, a change log, and settings that survive a restart. | [form](https://fand.github.io/egui-react/examples/form) | [lib.rs](examples/form/src/lib.rs) | [plain.rs](examples/form/src/plain.rs) |
-| `theme` | Two values provided at the top and read three levels down, with nothing in between. | [theme](https://fand.github.io/egui-react/examples/theme) | [lib.rs](examples/theme/src/lib.rs) | – |
-| `clock` | A stopwatch that asks for its own repaints, and an effect that cleans up after itself. | [clock](https://fand.github.io/egui-react/examples/clock) | [lib.rs](examples/clock/src/lib.rs) | – |
-| `custom-hook` | Three hooks of your own, each called from two components that keep their own state. | [custom-hook](https://fand.github.io/egui-react/examples/custom-hook) | [lib.rs](examples/custom-hook/src/lib.rs) | – |
-| `escape-hatch` | Four ways down to plain egui: a closure, a leaf, a painter, and a nested Cx. | [escape-hatch](https://fand.github.io/egui-react/examples/escape-hatch) | [lib.rs](examples/escape-hatch/src/lib.rs) | – |
-| `shader` | A wgpu fragment shader in a `<Canvas>`, with a slider wired to its uniform. | [shader](https://fand.github.io/egui-react/examples/shader) | [lib.rs](examples/shader/src/lib.rs) | – |
-| `list-10k` | Ten thousand rows: what drawing all of them costs, and what `<VirtualList>` saves. | [list-10k](https://fand.github.io/egui-react/examples/list-10k) | [lib.rs](examples/list-10k/src/lib.rs) | [plain.rs](examples/list-10k/src/plain.rs) |
-| `layout` | Every flex and grid attribute `<View>` understands, one section each. | [layout](https://fand.github.io/egui-react/examples/layout) | [lib.rs](examples/layout/src/lib.rs) | [plain.rs](examples/layout/src/plain.rs) |
-| `styles` | Every `style` attribute in a table: the name, the code that uses it, and what it draws. | [styles](https://fand.github.io/egui-react/examples/styles) | [lib.rs](examples/styles/src/lib.rs) | – |
-| `fetch` | `use_future` runs the request; the nearest `<Suspense>` draws the spinner. | [fetch](https://fand.github.io/egui-react/examples/fetch) | [lib.rs](examples/fetch/src/lib.rs) | – |
-| `font` | CSS-style font chains: a bundled subset, a 4.5 MB web font fetched on demand, and the installed fonts, with what each entry resolved to. | [font](https://fand.github.io/egui-react/examples/font) | [lib.rs](examples/font/src/lib.rs) | – |
+| `notes` | A notes app: reducer, persistence, context, memo and an editor, together. | [notes](https://fand.github.io/egui-reactor/examples/notes) | [lib.rs](examples/notes/src/lib.rs) | – |
+| `board` | Cards that keep the title being typed into them while they are dragged between columns. | [board](https://fand.github.io/egui-reactor/examples/board) | [lib.rs](examples/board/src/lib.rs) | [plain.rs](examples/board/src/plain.rs) |
+| `patch` | A node editor that generates, validates and previews its own WGSL shader. | [patch](https://fand.github.io/egui-reactor/examples/patch) | [lib.rs](examples/patch/src/lib.rs) | – |
+| `spreadsheet` | Formulas over 26 × 10,000 cells: two memo stages, and a draft that survives scrolling out of view. | [spreadsheet](https://fand.github.io/egui-reactor/examples/spreadsheet) | [lib.rs](examples/spreadsheet/src/lib.rs) | – |
+| `counter` | One piece of state, three handlers that borrow it in turn. | [counter](https://fand.github.io/egui-reactor/examples/counter) | [lib.rs](examples/counter/src/lib.rs) | – |
+| `todo` | A reducer drives the list; `use_persisted` keeps it across restarts. | [todo](https://fand.github.io/egui-reactor/examples/todo) | [lib.rs](examples/todo/src/lib.rs) | [plain.rs](examples/todo/src/plain.rs) |
+| `form` | Every bound widget, a change log, and settings that survive a restart. | [form](https://fand.github.io/egui-reactor/examples/form) | [lib.rs](examples/form/src/lib.rs) | [plain.rs](examples/form/src/plain.rs) |
+| `theme` | Two values provided at the top and read three levels down, with nothing in between. | [theme](https://fand.github.io/egui-reactor/examples/theme) | [lib.rs](examples/theme/src/lib.rs) | – |
+| `clock` | A stopwatch that asks for its own repaints, and an effect that cleans up after itself. | [clock](https://fand.github.io/egui-reactor/examples/clock) | [lib.rs](examples/clock/src/lib.rs) | – |
+| `custom-hook` | Three hooks of your own, each called from two components that keep their own state. | [custom-hook](https://fand.github.io/egui-reactor/examples/custom-hook) | [lib.rs](examples/custom-hook/src/lib.rs) | – |
+| `escape-hatch` | Four ways down to plain egui: a closure, a leaf, a painter, and a nested Cx. | [escape-hatch](https://fand.github.io/egui-reactor/examples/escape-hatch) | [lib.rs](examples/escape-hatch/src/lib.rs) | – |
+| `shader` | A wgpu fragment shader in a `<Canvas>`, with a slider wired to its uniform. | [shader](https://fand.github.io/egui-reactor/examples/shader) | [lib.rs](examples/shader/src/lib.rs) | – |
+| `list-10k` | Ten thousand rows: what drawing all of them costs, and what `<VirtualList>` saves. | [list-10k](https://fand.github.io/egui-reactor/examples/list-10k) | [lib.rs](examples/list-10k/src/lib.rs) | [plain.rs](examples/list-10k/src/plain.rs) |
+| `layout` | Every flex and grid attribute `<View>` understands, one section each. | [layout](https://fand.github.io/egui-reactor/examples/layout) | [lib.rs](examples/layout/src/lib.rs) | [plain.rs](examples/layout/src/plain.rs) |
+| `styles` | Every `style` attribute in a table: the name, the code that uses it, and what it draws. | [styles](https://fand.github.io/egui-reactor/examples/styles) | [lib.rs](examples/styles/src/lib.rs) | – |
+| `fetch` | `use_future` runs the request; the nearest `<Suspense>` draws the spinner. | [fetch](https://fand.github.io/egui-reactor/examples/fetch) | [lib.rs](examples/fetch/src/lib.rs) | – |
+| `font` | CSS-style font chains: a bundled subset, a 4.5 MB web font fetched on demand, and the installed fonts, with what each entry resolved to. | [font](https://fand.github.io/egui-reactor/examples/font) | [lib.rs](examples/font/src/lib.rs) | – |
 
 Run one natively, or in a browser with [trunk](https://trunkrs.dev/):
 

--- a/crates/egui-reactor-elements/src/suspense.rs
+++ b/crates/egui-reactor-elements/src/suspense.rs
@@ -61,14 +61,18 @@ pub fn Suspense(cx: &mut Cx, fallback: impl View, children: impl View) {
         }
         if store.end_suspense() == 0 {
             suspended.set(false);
-            store.ctx().request_discard("egui-reactor: suspense resolved");
+            store
+                .ctx()
+                .request_discard("egui-reactor: suspense resolved");
         }
     } else {
         store.begin_suspense();
         children.show(cx);
         if store.end_suspense() > 0 {
             suspended.set(true);
-            store.ctx().request_discard("egui-reactor: suspense pending");
+            store
+                .ctx()
+                .request_discard("egui-reactor: suspense pending");
         }
     }
 }

--- a/crates/egui-reactor-macros/src/rsx/control_flow.rs
+++ b/crates/egui-reactor-macros/src/rsx/control_flow.rs
@@ -89,7 +89,9 @@ fn parse_children(
     while !content.is_empty() {
         let node = parser
             .parse_recoverable::<Node<ControlFlow>>(&content)
-            .ok_or_else(|| syn::Error::new(content.span(), "egui-reactor: expected an rsx! node"))?;
+            .ok_or_else(|| {
+                syn::Error::new(content.span(), "egui-reactor: expected an rsx! node")
+            })?;
         nodes.push(node);
     }
     Ok(nodes)

--- a/crates/egui-reactor/src/hooks.rs
+++ b/crates/egui-reactor/src/hooks.rs
@@ -106,7 +106,9 @@ pub fn use_persisted<'s, T: Serialize + DeserializeOwned + 'static>(
                 .and_then(|json| match serde_json::from_str::<T>(&json) {
                     Ok(value) => Some(value),
                     Err(err) => {
-                        log::warn!("egui-reactor: persisted value {key:?} could not be read: {err}");
+                        log::warn!(
+                            "egui-reactor: persisted value {key:?} could not be read: {err}"
+                        );
                         None
                     }
                 });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -574,9 +574,9 @@ Decisions are recorded in [docs/adr/](adr/), one file per decision, grouped by d
 
 ## 12. Website
 
-`https://fand.github.io/egui-react/` is a [VitePress](https://vitepress.dev/) site in `site/`: a home page, Getting Started, a guide, a reference (hooks, elements, layout attributes) and one page per example. It replaced the gallery wasm, which was everything the site used to be; the decision and what was turned down are in [adr/app/0001](adr/app/0001-site-is-vitepress-with-one-embed-wasm.md). Numbered last because it is the only section about the published artefact rather than the library.
+`https://fand.github.io/egui-reactor/` is a [VitePress](https://vitepress.dev/) site in `site/`: a home page, Getting Started, a guide, a reference (hooks, elements, layout attributes) and one page per example. It replaced the gallery wasm, which was everything the site used to be; the decision and what was turned down are in [adr/app/0001](adr/app/0001-site-is-vitepress-with-one-embed-wasm.md). Numbered last because it is the only section about the published artefact rather than the library.
 
-Three things are served from one directory, assembled by `site/build.sh` (the one place the assembly lives; the workflows and a human run the same script, with `SITE_BASE` `/egui-react/` on GitHub Pages and `/` on the Cloudflare PR preview).
+Three things are served from one directory, assembled by `site/build.sh` (the one place the assembly lives; the workflows and a human run the same script, with `SITE_BASE` `/egui-reactor/` on GitHub Pages and `/` on the Cloudflare PR preview).
 
 | URL | What | Built by |
 |---|---|---|

--- a/examples/gallery/src/lib.rs
+++ b/examples/gallery/src/lib.rs
@@ -61,7 +61,7 @@ pub const EXAMPLES: &[Meta] = &[
 ];
 
 /// Where the source links point.
-const REPO: &str = "https://github.com/fand/egui-react/blob/main/examples";
+const REPO: &str = "https://github.com/fand/egui-reactor/blob/main/examples";
 
 /// Below this window width the gallery is one pane and a menu rather than
 /// three columns.

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitepress'
 import { exampleSourcePlugin } from '../lib/example-source.js'
 import { EXAMPLE_ORDER } from '../lib/examples-order.js'
 
-// GitHub Pages serves the site under `/egui-react/`, the Cloudflare preview
+// GitHub Pages serves the site under `/egui-reactor/`, the Cloudflare preview
 // under `/`; `site/build.sh` passes whichever applies. A trailing slash is
 // what VitePress and `withBase` expect.
 const base = process.env.SITE_BASE ?? '/'
@@ -23,7 +23,7 @@ const pages = new Set(
 )
 const known = EXAMPLE_ORDER.filter((name) => pages.has(name))
 
-/// `https://fand.github.io/egui-react/#counter` was the gallery; it is now an
+/// `https://fand.github.io/egui-reactor/#counter` was the gallery; it is now an
 /// example page. Inline in `head` so it runs before the router hydrates and the
 /// reader never sees the home page flash by.
 const redirect = `
@@ -191,7 +191,7 @@ export default defineConfig({
         nav: nav('/ja', JA),
         sidebar: sidebar('/ja', JA),
         editLink: {
-          pattern: 'https://github.com/fand/egui-react/edit/main/site/:path',
+          pattern: 'https://github.com/fand/egui-reactor/edit/main/site/:path',
           text: 'このページを GitHub で編集する'
         },
         outline: { label: '目次' },
@@ -263,9 +263,9 @@ export default defineConfig({
         }
       }
     },
-    socialLinks: [{ icon: 'github', link: 'https://github.com/fand/egui-react' }],
+    socialLinks: [{ icon: 'github', link: 'https://github.com/fand/egui-reactor' }],
     editLink: {
-      pattern: 'https://github.com/fand/egui-react/edit/main/site/:path',
+      pattern: 'https://github.com/fand/egui-reactor/edit/main/site/:path',
       text: 'Edit this page on GitHub'
     },
     footer: {

--- a/site/architecture.md
+++ b/site/architecture.md
@@ -5,7 +5,7 @@ title: Architecture
 # Architecture
 
 <script setup>
-// `withBase`, because the site is served from `/egui-react/` on GitHub Pages
+// `withBase`, because the site is served from `/egui-reactor/` on GitHub Pages
 // and from `/` on the preview; `/api/` is cargo doc's output, not a page of
 // this site, so it is a plain link and not a router route.
 import { withBase } from 'vitepress'
@@ -17,7 +17,7 @@ says where they are.
 
 ## `docs/ARCHITECTURE.md`
 
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md)
 is the deep reference: what is true about the implementation right now. Goals
 and non-goals, `Cx` and the `View` trait, what `#[component]` and `rsx!`
 generate, the hook list with its exact semantics, the runtime (store, sweep,
@@ -31,7 +31,7 @@ something, it links the section there rather than repeating it.
 
 ## `docs/adr/`
 
-[docs/adr/](https://github.com/fand/egui-react/tree/main/docs/adr) is the
+[docs/adr/](https://github.com/fand/egui-reactor/tree/main/docs/adr) is the
 decision log: one file per design decision, grouped by domain — `core`,
 `runtime`, `layout`, `elements`, `fonts`, `a11y`, `app`. Each records when the
 decision was made, what was decided, what was turned down and why, and what it
@@ -64,5 +64,5 @@ pieces fit together.
 
 ## The repository
 
-[github.com/fand/egui-react](https://github.com/fand/egui-react). Issues and
+[github.com/fand/egui-reactor](https://github.com/fand/egui-reactor). Issues and
 pull requests welcome; the tests to run before opening one are in the README.

--- a/site/build.sh
+++ b/site/build.sh
@@ -2,7 +2,7 @@
 #
 # Build the whole published site into `site/.vitepress/dist`.
 #
-# Called by .github/workflows/pages.yml (SITE_BASE=/egui-react/), by
+# Called by .github/workflows/pages.yml (SITE_BASE=/egui-reactor/), by
 # .github/workflows/preview-cloudflare-pages.yml (SITE_BASE=/), and by anyone
 # who wants to see locally what will be deployed. It is the one place the
 # assembly lives, so the two deploys cannot drift apart.

--- a/site/examples/board.md
+++ b/site/examples/board.md
@@ -75,7 +75,7 @@ cargo run -p board --bin board-plain    # the plain egui version
 trunk serve --config examples/board/Trunk.toml
 ```
 
-The source is [`examples/board/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/board/src/lib.rs)
-and [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/board/src/plain.rs).
+The source is [`examples/board/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/board/src/lib.rs)
+and [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/board/src/plain.rs).
 
 </ExamplePage>

--- a/site/examples/clock.md
+++ b/site/examples/clock.md
@@ -57,6 +57,6 @@ cargo run -p clock
 trunk serve --config examples/clock/Trunk.toml
 ```
 
-The source is [`examples/clock/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/clock/src/lib.rs).
+The source is [`examples/clock/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/clock/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/counter.md
+++ b/site/examples/counter.md
@@ -45,6 +45,6 @@ cargo run -p counter
 trunk serve --config examples/counter/Trunk.toml
 ```
 
-The source is [`examples/counter/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/counter/src/lib.rs).
+The source is [`examples/counter/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/counter/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/custom-hook.md
+++ b/site/examples/custom-hook.md
@@ -58,7 +58,7 @@ cargo run -p custom-hook
 trunk serve --config examples/custom-hook/Trunk.toml
 ```
 
-The source is [`examples/custom-hook/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/custom-hook/src/lib.rs);
-the hooks themselves are in [`src/hooks.rs`](https://github.com/fand/egui-react/blob/main/examples/custom-hook/src/hooks.rs).
+The source is [`examples/custom-hook/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/custom-hook/src/lib.rs);
+the hooks themselves are in [`src/hooks.rs`](https://github.com/fand/egui-reactor/blob/main/examples/custom-hook/src/hooks.rs).
 
 </ExamplePage>

--- a/site/examples/escape-hatch.md
+++ b/site/examples/escape-hatch.md
@@ -62,6 +62,6 @@ cargo run -p escape-hatch
 trunk serve --config examples/escape-hatch/Trunk.toml
 ```
 
-The source is [`examples/escape-hatch/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/escape-hatch/src/lib.rs).
+The source is [`examples/escape-hatch/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/escape-hatch/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/fetch.md
+++ b/site/examples/fetch.md
@@ -60,6 +60,6 @@ cargo run -p fetch
 trunk serve --config examples/fetch/Trunk.toml
 ```
 
-The source is [`examples/fetch/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/fetch/src/lib.rs).
+The source is [`examples/fetch/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/fetch/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/font.md
+++ b/site/examples/font.md
@@ -68,6 +68,6 @@ downloads it the first time trunk builds. Natively the same relative URL has no
 server to point at, so that entry is reported as failed and the chain draws with
 the subset — the report shows that too.
 
-The source is [`examples/font/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/font/src/lib.rs).
+The source is [`examples/font/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/font/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/form.md
+++ b/site/examples/form.md
@@ -64,7 +64,7 @@ cargo run -p form --bin form-plain    # the plain egui version
 trunk serve --config examples/form/Trunk.toml
 ```
 
-The source is [`examples/form/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/form/src/lib.rs)
-and [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/form/src/plain.rs).
+The source is [`examples/form/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/form/src/lib.rs)
+and [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/form/src/plain.rs).
 
 </ExamplePage>

--- a/site/examples/layout.md
+++ b/site/examples/layout.md
@@ -66,7 +66,7 @@ cargo run -p layout --bin layout-plain    # the plain egui version
 trunk serve --config examples/layout/Trunk.toml
 ```
 
-The source is [`examples/layout/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/layout/src/lib.rs)
-and [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/layout/src/plain.rs).
+The source is [`examples/layout/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/layout/src/lib.rs)
+and [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/layout/src/plain.rs).
 
 </ExamplePage>

--- a/site/examples/list-10k.md
+++ b/site/examples/list-10k.md
@@ -67,7 +67,7 @@ cargo run -p list-10k --bin list-10k-plain    # the plain egui version
 trunk serve --config examples/list-10k/Trunk.toml
 ```
 
-The source is [`examples/list-10k/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/list-10k/src/lib.rs)
-and [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/list-10k/src/plain.rs).
+The source is [`examples/list-10k/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/list-10k/src/lib.rs)
+and [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/list-10k/src/plain.rs).
 
 </ExamplePage>

--- a/site/examples/notes.md
+++ b/site/examples/notes.md
@@ -67,6 +67,6 @@ cargo run -p notes
 trunk serve --config examples/notes/Trunk.toml
 ```
 
-The source is [`examples/notes/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/notes/src/lib.rs).
+The source is [`examples/notes/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/notes/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/patch.md
+++ b/site/examples/patch.md
@@ -73,6 +73,6 @@ cargo run -p patch
 trunk serve --config examples/patch/Trunk.toml
 ```
 
-The source is [`examples/patch/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/patch/src/lib.rs).
+The source is [`examples/patch/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/patch/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/shader.md
+++ b/site/examples/shader.md
@@ -59,8 +59,8 @@ cargo run -p shader
 trunk serve --config examples/shader/Trunk.toml
 ```
 
-The source is [`examples/shader/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/shader/src/lib.rs);
-the pipeline is in [`src/gpu.rs`](https://github.com/fand/egui-react/blob/main/examples/shader/src/gpu.rs)
-and the shader in [`src/shader.wgsl`](https://github.com/fand/egui-react/blob/main/examples/shader/src/shader.wgsl).
+The source is [`examples/shader/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/shader/src/lib.rs);
+the pipeline is in [`src/gpu.rs`](https://github.com/fand/egui-reactor/blob/main/examples/shader/src/gpu.rs)
+and the shader in [`src/shader.wgsl`](https://github.com/fand/egui-reactor/blob/main/examples/shader/src/shader.wgsl).
 
 </ExamplePage>

--- a/site/examples/spreadsheet.md
+++ b/site/examples/spreadsheet.md
@@ -63,6 +63,6 @@ cargo run -p spreadsheet
 trunk serve --config examples/spreadsheet/Trunk.toml
 ```
 
-The source is [`examples/spreadsheet/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/spreadsheet/src/lib.rs).
+The source is [`examples/spreadsheet/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/spreadsheet/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/styles.md
+++ b/site/examples/styles.md
@@ -58,6 +58,6 @@ cargo run -p styles
 trunk serve --config examples/styles/Trunk.toml
 ```
 
-The source is [`examples/styles/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/styles/src/lib.rs).
+The source is [`examples/styles/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/styles/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/theme.md
+++ b/site/examples/theme.md
@@ -61,6 +61,6 @@ cargo run -p theme
 trunk serve --config examples/theme/Trunk.toml
 ```
 
-The source is [`examples/theme/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/theme/src/lib.rs).
+The source is [`examples/theme/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/theme/src/lib.rs).
 
 </ExamplePage>

--- a/site/examples/todo.md
+++ b/site/examples/todo.md
@@ -68,7 +68,7 @@ cargo run -p todo --bin todo-plain    # the plain egui version
 trunk serve --config examples/todo/Trunk.toml
 ```
 
-The source is [`examples/todo/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/todo/src/lib.rs)
-and [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/todo/src/plain.rs).
+The source is [`examples/todo/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/todo/src/lib.rs)
+and [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/todo/src/plain.rs).
 
 </ExamplePage>

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -33,9 +33,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-egui-reactor = { git = "https://github.com/fand/egui-react" }
-egui-reactor-elements = { git = "https://github.com/fand/egui-react" }
-egui-reactor-app = { git = "https://github.com/fand/egui-react" }
+egui-reactor = { git = "https://github.com/fand/egui-reactor" }
+egui-reactor-elements = { git = "https://github.com/fand/egui-reactor" }
+egui-reactor-app = { git = "https://github.com/fand/egui-reactor" }
 egui = "0.36.1"
 eframe = "0.36.1"
 ```

--- a/site/guide/async.md
+++ b/site/guide/async.md
@@ -100,5 +100,5 @@ HTTP. Do CPU-heavy work on a thread you start inside the future.
 
 [fetch](/examples/fetch) is this page in one screen. [patch](/examples/patch)
 uses `<Suspense>` around shader compilation. The mechanism is in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#58-suspense)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#58-suspense)
 sections 4 and 5.8.

--- a/site/guide/components-and-events.md
+++ b/site/guide/components-and-events.md
@@ -137,5 +137,5 @@ and `Suspense` use it. You only need it when wrapping such a container.
 [theme](/examples/theme) is a provider component. [notes](/examples/notes)
 puts components, events and a reducer together. The generated code is
 described in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#33-components)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#33-components)
 sections 3.3 and 3.6.

--- a/site/guide/fonts.md
+++ b/site/guide/fonts.md
@@ -130,6 +130,6 @@ wanted.
 
 [font](/examples/font) has all four chains, the three sources, the per-entry
 report, and the `swap` versus `block` switch. The resolver is in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#8-platforms)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#8-platforms)
 section 8, and the decisions in
-[docs/adr/fonts/](https://github.com/fand/egui-react/tree/main/docs/adr/fonts).
+[docs/adr/fonts/](https://github.com/fand/egui-reactor/tree/main/docs/adr/fonts).

--- a/site/guide/layout.md
+++ b/site/guide/layout.md
@@ -145,5 +145,5 @@ state. Use `if` when the state should go.
 [layout](/examples/layout) walks every flex and grid attribute.
 [styles](/examples/styles) does the same for paint. [board](/examples/board)
 is a real screen built from them. The engine is described in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#6-layout)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#6-layout)
 section 6.

--- a/site/guide/rsx.md
+++ b/site/guide/rsx.md
@@ -155,5 +155,5 @@ Hooks work in there, since it is the same `Cx`. Draw through `cx.leaf`, not
 [layout](/examples/layout) and [styles](/examples/styles) show one attribute
 at a time. [notes](/examples/notes) uses the whole syntax. The macro's rules
 are in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#32-view-and-rsx)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#32-view-and-rsx)
 section 3.2.

--- a/site/guide/state-and-hooks.md
+++ b/site/guide/state-and-hooks.md
@@ -174,5 +174,5 @@ are in the [Hooks reference](/reference/hooks).
 `bind`, [todo](/examples/todo) for `use_reducer` and `use_persisted`,
 [theme](/examples/theme) for context, [custom-hook](/examples/custom-hook)
 for `#[hook]`. The store and repaint policy are in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#5-runtime)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#5-runtime)
 section 5.

--- a/site/guide/web-and-native.md
+++ b/site/guide/web-and-native.md
@@ -121,5 +121,5 @@ site is HTML and only the examples are wasm.
 Every example page is the same wasm build, told which example to draw by the
 URL. [shader](/examples/shader) is the wgpu path. [font](/examples/font)
 fetches a font over HTTP. The runner and platform notes are in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#7-crate-layout)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#7-crate-layout)
 sections 7 and 8.

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -98,5 +98,5 @@ a tree. See [Escape hatches](/guide/escape-hatches).
 [counter](/examples/counter) is the smallest example.
 [notes](/examples/notes) uses most of the library at once. The runtime
 details are in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md)
 sections 2 and 5.

--- a/site/index.md
+++ b/site/index.md
@@ -16,7 +16,7 @@ hero:
       link: /examples/
     - theme: alt
       text: GitHub
-      link: https://github.com/fand/egui-react
+      link: https://github.com/fand/egui-reactor
 ---
 
 <script setup>

--- a/site/ja/architecture.md
+++ b/site/ja/architecture.md
@@ -5,7 +5,7 @@ title: アーキテクチャ
 # アーキテクチャ
 
 <script setup>
-// `withBase` を使うのは、このサイトが GitHub Pages では `/egui-react/`、
+// `withBase` を使うのは、このサイトが GitHub Pages では `/egui-reactor/`、
 // プレビューでは `/` から配信されるため。`/api/` は cargo doc の出力で、
 // このサイトのページではないので、ルータのルートではなく素のリンクにする。
 import { withBase } from 'vitepress'
@@ -15,13 +15,13 @@ import { withBase } from 'vitepress'
 
 ## `docs/ARCHITECTURE.md`
 
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md)が深いほうのリファレンスで、実装について「いま何が本当か」を書いています。目標と非目標、`Cx` と `View` トレイト、`#[component]` と `rsx!` が生成するもの、フック一覧とその正確な意味、ランタイム（ストア、掃除、マルチパス、再描画の方針、`<Suspense>`）、taffy の上のレイアウトエンジンとリストの行のための軽量パス、要素一覧、クレート構成、プラットフォームの注意、テスト戦略。
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md)が深いほうのリファレンスで、実装について「いま何が本当か」を書いています。目標と非目標、`Cx` と `View` トレイト、`#[component]` と `rsx!` が生成するもの、フック一覧とその正確な意味、ランタイム（ストア、掃除、マルチパス、再描画の方針、`<Suspense>`）、taffy の上のレイアウトエンジンとリストの行のための軽量パス、要素一覧、クレート構成、プラットフォームの注意、テスト戦略。
 
 このサイトのガイドはアプリを作る人に向けて書いてあります。ARCHITECTURE はライブラリを変える人に向けたものです。ガイドのページが何かを要約するときは、繰り返さずに向こうの節へリンクします。
 
 ## `docs/adr/`
 
-[docs/adr/](https://github.com/fand/egui-react/tree/main/docs/adr) は決定の記録です。設計上の決定 1 つにつき 1 ファイルで、ドメインごとに分けてあります。`core`、`runtime`、`layout`、`elements`、`fonts`、`a11y`、`app`。それぞれに、いつ決めたか、何を決めたか、何を退けたか、その理由、そして何を代償にしたかが書いてあります。
+[docs/adr/](https://github.com/fand/egui-reactor/tree/main/docs/adr) は決定の記録です。設計上の決定 1 つにつき 1 ファイルで、ドメインごとに分けてあります。`core`、`runtime`、`layout`、`elements`、`fonts`、`a11y`、`app`。それぞれに、いつ決めたか、何を決めたか、何を退けたか、その理由、そして何を代償にしたかが書いてあります。
 
 規律はわざと狭くしてあります。この記録を読む価値のあるものにしているのが、それです。
 
@@ -37,4 +37,4 @@ import { withBase } from 'vitepress'
 
 ## リポジトリ
 
-[github.com/fand/egui-react](https://github.com/fand/egui-react)。Issue もプルリクエストも歓迎します。出す前に走らせるテストは README にあります。
+[github.com/fand/egui-reactor](https://github.com/fand/egui-reactor)。Issue もプルリクエストも歓迎します。出す前に走らせるテストは README にあります。

--- a/site/ja/examples/board.md
+++ b/site/ja/examples/board.md
@@ -53,6 +53,6 @@ cargo run -p board --bin board-plain    # 素の egui 版
 trunk serve --config examples/board/Trunk.toml
 ```
 
-ソースは [`examples/board/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/board/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/board/src/plain.rs) です。
+ソースは [`examples/board/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/board/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/board/src/plain.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/clock.md
+++ b/site/ja/examples/clock.md
@@ -43,6 +43,6 @@ cargo run -p clock
 trunk serve --config examples/clock/Trunk.toml
 ```
 
-ソースは [`examples/clock/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/clock/src/lib.rs) です。
+ソースは [`examples/clock/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/clock/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/counter.md
+++ b/site/ja/examples/counter.md
@@ -41,6 +41,6 @@ cargo run -p counter
 trunk serve --config examples/counter/Trunk.toml
 ```
 
-ソースは [`examples/counter/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/counter/src/lib.rs) です。
+ソースは [`examples/counter/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/counter/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/custom-hook.md
+++ b/site/ja/examples/custom-hook.md
@@ -43,6 +43,6 @@ cargo run -p custom-hook
 trunk serve --config examples/custom-hook/Trunk.toml
 ```
 
-ソースは [`examples/custom-hook/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/custom-hook/src/lib.rs)、フック自体は [`src/hooks.rs`](https://github.com/fand/egui-react/blob/main/examples/custom-hook/src/hooks.rs) にあります。
+ソースは [`examples/custom-hook/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/custom-hook/src/lib.rs)、フック自体は [`src/hooks.rs`](https://github.com/fand/egui-reactor/blob/main/examples/custom-hook/src/hooks.rs) にあります。
 
 </ExamplePage>

--- a/site/ja/examples/escape-hatch.md
+++ b/site/ja/examples/escape-hatch.md
@@ -45,6 +45,6 @@ cargo run -p escape-hatch
 trunk serve --config examples/escape-hatch/Trunk.toml
 ```
 
-ソースは [`examples/escape-hatch/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/escape-hatch/src/lib.rs) です。
+ソースは [`examples/escape-hatch/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/escape-hatch/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/fetch.md
+++ b/site/ja/examples/fetch.md
@@ -43,6 +43,6 @@ cargo run -p fetch
 trunk serve --config examples/fetch/Trunk.toml
 ```
 
-ソースは [`examples/fetch/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/fetch/src/lib.rs) です。
+ソースは [`examples/fetch/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/fetch/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/font.md
+++ b/site/ja/examples/font.md
@@ -45,6 +45,6 @@ trunk serve --config examples/font/Trunk.toml
 
 Web フォントはコミットしていません。このサンプルの `Trunk.toml` にあるビルド前フックが、trunk の初回ビルド時にダウンロードします。ネイティブでは同じ相対 URL に指す先のサーバが無いので、その項目は失敗として報告され、チェーンはサブセットで描きます。レポートにはそれも出ます。
 
-ソースは [`examples/font/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/font/src/lib.rs) です。
+ソースは [`examples/font/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/font/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/form.md
+++ b/site/ja/examples/form.md
@@ -51,6 +51,6 @@ cargo run -p form --bin form-plain    # 素の egui 版
 trunk serve --config examples/form/Trunk.toml
 ```
 
-ソースは [`examples/form/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/form/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/form/src/plain.rs) です。
+ソースは [`examples/form/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/form/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/form/src/plain.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/layout.md
+++ b/site/ja/examples/layout.md
@@ -51,6 +51,6 @@ cargo run -p layout --bin layout-plain    # 素の egui 版
 trunk serve --config examples/layout/Trunk.toml
 ```
 
-ソースは [`examples/layout/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/layout/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/layout/src/plain.rs) です。
+ソースは [`examples/layout/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/layout/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/layout/src/plain.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/list-10k.md
+++ b/site/ja/examples/list-10k.md
@@ -51,6 +51,6 @@ cargo run -p list-10k --bin list-10k-plain    # 素の egui 版
 trunk serve --config examples/list-10k/Trunk.toml
 ```
 
-ソースは [`examples/list-10k/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/list-10k/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/list-10k/src/plain.rs) です。
+ソースは [`examples/list-10k/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/list-10k/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/list-10k/src/plain.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/notes.md
+++ b/site/ja/examples/notes.md
@@ -45,6 +45,6 @@ cargo run -p notes
 trunk serve --config examples/notes/Trunk.toml
 ```
 
-ソースは [`examples/notes/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/notes/src/lib.rs) です。
+ソースは [`examples/notes/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/notes/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/patch.md
+++ b/site/ja/examples/patch.md
@@ -45,6 +45,6 @@ cargo run -p patch
 trunk serve --config examples/patch/Trunk.toml
 ```
 
-ソースは [`examples/patch/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/patch/src/lib.rs) です。
+ソースは [`examples/patch/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/patch/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/shader.md
+++ b/site/ja/examples/shader.md
@@ -43,6 +43,6 @@ cargo run -p shader
 trunk serve --config examples/shader/Trunk.toml
 ```
 
-ソースは [`examples/shader/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/shader/src/lib.rs)、パイプラインは [`src/gpu.rs`](https://github.com/fand/egui-react/blob/main/examples/shader/src/gpu.rs)、シェーダは [`src/shader.wgsl`](https://github.com/fand/egui-react/blob/main/examples/shader/src/shader.wgsl) にあります。
+ソースは [`examples/shader/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/shader/src/lib.rs)、パイプラインは [`src/gpu.rs`](https://github.com/fand/egui-reactor/blob/main/examples/shader/src/gpu.rs)、シェーダは [`src/shader.wgsl`](https://github.com/fand/egui-reactor/blob/main/examples/shader/src/shader.wgsl) にあります。
 
 </ExamplePage>

--- a/site/ja/examples/spreadsheet.md
+++ b/site/ja/examples/spreadsheet.md
@@ -43,6 +43,6 @@ cargo run -p spreadsheet
 trunk serve --config examples/spreadsheet/Trunk.toml
 ```
 
-ソースは [`examples/spreadsheet/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/spreadsheet/src/lib.rs) です。
+ソースは [`examples/spreadsheet/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/spreadsheet/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/styles.md
+++ b/site/ja/examples/styles.md
@@ -43,6 +43,6 @@ cargo run -p styles
 trunk serve --config examples/styles/Trunk.toml
 ```
 
-ソースは [`examples/styles/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/styles/src/lib.rs) です。
+ソースは [`examples/styles/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/styles/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/theme.md
+++ b/site/ja/examples/theme.md
@@ -43,6 +43,6 @@ cargo run -p theme
 trunk serve --config examples/theme/Trunk.toml
 ```
 
-ソースは [`examples/theme/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/theme/src/lib.rs) です。
+ソースは [`examples/theme/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/theme/src/lib.rs) です。
 
 </ExamplePage>

--- a/site/ja/examples/todo.md
+++ b/site/ja/examples/todo.md
@@ -53,6 +53,6 @@ cargo run -p todo --bin todo-plain    # 素の egui 版
 trunk serve --config examples/todo/Trunk.toml
 ```
 
-ソースは [`examples/todo/src/lib.rs`](https://github.com/fand/egui-react/blob/main/examples/todo/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-react/blob/main/examples/todo/src/plain.rs) です。
+ソースは [`examples/todo/src/lib.rs`](https://github.com/fand/egui-reactor/blob/main/examples/todo/src/lib.rs)と [`plain.rs`](https://github.com/fand/egui-reactor/blob/main/examples/todo/src/plain.rs) です。
 
 </ExamplePage>

--- a/site/ja/getting-started.md
+++ b/site/ja/getting-started.md
@@ -32,9 +32,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-egui-reactor = { git = "https://github.com/fand/egui-react" }
-egui-reactor-elements = { git = "https://github.com/fand/egui-react" }
-egui-reactor-app = { git = "https://github.com/fand/egui-react" }
+egui-reactor = { git = "https://github.com/fand/egui-reactor" }
+egui-reactor-elements = { git = "https://github.com/fand/egui-reactor" }
+egui-reactor-app = { git = "https://github.com/fand/egui-reactor" }
 egui = "0.36.1"
 eframe = "0.36.1"
 ```

--- a/site/ja/guide/async.md
+++ b/site/ja/guide/async.md
@@ -85,4 +85,4 @@ future の実行中に deps が変わっても、古い future は止まりま�
 
 ## 動かして見る
 
-[fetch](/ja/examples/fetch) はこのページを 1 画面にしたものです。[patch](/ja/examples/patch) はシェーダのコンパイルを `<Suspense>` で包みます。仕組みは[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#58-suspense)の 4 章と 5.8 節にあります（英語）。
+[fetch](/ja/examples/fetch) はこのページを 1 画面にしたものです。[patch](/ja/examples/patch) はシェーダのコンパイルを `<Suspense>` で包みます。仕組みは[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#58-suspense)の 4 章と 5.8 節にあります（英語）。

--- a/site/ja/guide/components-and-events.md
+++ b/site/ja/guide/components-and-events.md
@@ -114,4 +114,4 @@ use crate::components::{Dialog, DialogEvent};
 
 ## 動かして見る
 
-[form](/ja/examples/form) は束縛できるウィジェット全部に対する props とイベントです。[theme](/ja/examples/theme) はプロバイダのコンポーネント、[notes](/ja/examples/notes) はコンポーネント・イベント・reducer をまとめて使います。生成されるコードの説明は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#33-components)の 3.3 節と 3.6 節にあります（英語）。
+[form](/ja/examples/form) は束縛できるウィジェット全部に対する props とイベントです。[theme](/ja/examples/theme) はプロバイダのコンポーネント、[notes](/ja/examples/notes) はコンポーネント・イベント・reducer をまとめて使います。生成されるコードの説明は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#33-components)の 3.3 節と 3.6 節にあります（英語）。

--- a/site/ja/guide/fonts.md
+++ b/site/ja/guide/fonts.md
@@ -99,4 +99,4 @@ Fonts::new().stack(
 
 ## 動かして見る
 
-[font](/ja/examples/font) には 4 つのチェーン、3 つのソース、項目ごとのレポート、`swap` と `block` の切り替えが入っています。リゾルバの説明は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#8-platforms)の 8 章、決定の記録は[docs/adr/fonts/](https://github.com/fand/egui-react/tree/main/docs/adr/fonts)にあります（どちらも英語）。
+[font](/ja/examples/font) には 4 つのチェーン、3 つのソース、項目ごとのレポート、`swap` と `block` の切り替えが入っています。リゾルバの説明は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#8-platforms)の 8 章、決定の記録は[docs/adr/fonts/](https://github.com/fand/egui-reactor/tree/main/docs/adr/fonts)にあります（どちらも英語）。

--- a/site/ja/guide/layout.md
+++ b/site/ja/guide/layout.md
@@ -116,4 +116,4 @@ if showing {
 
 ## 動かして見る
 
-[layout](/ja/examples/layout) は flex と grid の属性を全部たどります。[styles](/ja/examples/styles) は描画側で同じことをします。[board](/ja/examples/board) はそれらで組んだ実際の画面です。エンジンの説明は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#6-layout)の 6 章にあります（英語）。
+[layout](/ja/examples/layout) は flex と grid の属性を全部たどります。[styles](/ja/examples/styles) は描画側で同じことをします。[board](/ja/examples/board) はそれらで組んだ実際の画面です。エンジンの説明は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#6-layout)の 6 章にあります（英語）。

--- a/site/ja/guide/rsx.md
+++ b/site/ja/guide/rsx.md
@@ -135,4 +135,4 @@ rsx! {
 
 ## 動かして見る
 
-[layout](/ja/examples/layout) と [styles](/ja/examples/styles) は属性を 1 つずつ見せます。[notes](/ja/examples/notes) は文法をひととおり使います。マクロの規則は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#32-view-and-rsx)の 3.2 節にあります（英語）。
+[layout](/ja/examples/layout) と [styles](/ja/examples/styles) は属性を 1 つずつ見せます。[notes](/ja/examples/notes) は文法をひととおり使います。マクロの規則は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#32-view-and-rsx)の 3.2 節にあります（英語）。

--- a/site/ja/guide/state-and-hooks.md
+++ b/site/ja/guide/state-and-hooks.md
@@ -146,4 +146,4 @@ for (i, todo) in todos.iter().enumerate() {
 
 ## 動かして見る
 
-ガードは [counter](/ja/examples/counter)、`bind` は [form](/ja/examples/form)、`use_reducer` と `use_persisted` は [todo](/ja/examples/todo)、コンテキストは[theme](/ja/examples/theme)、`#[hook]` は[custom-hook](/ja/examples/custom-hook) を見てください。ストアと再描画の方針は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#5-runtime)の 5 章にあります（英語）。
+ガードは [counter](/ja/examples/counter)、`bind` は [form](/ja/examples/form)、`use_reducer` と `use_persisted` は [todo](/ja/examples/todo)、コンテキストは[theme](/ja/examples/theme)、`#[hook]` は[custom-hook](/ja/examples/custom-hook) を見てください。ストアと再描画の方針は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#5-runtime)の 5 章にあります（英語）。

--- a/site/ja/guide/web-and-native.md
+++ b/site/ja/guide/web-and-native.md
@@ -98,4 +98,4 @@ wasm 以外のターゲットでは中身が空なので、条件を付けずに
 
 ## 動かして見る
 
-どのサンプルページも同じ wasm ビルドで、どれを描くかは URL で伝えています。wgpu の道筋は [shader](/ja/examples/shader)、HTTP でのフォント取得は[font](/ja/examples/font) です。ランナーとプラットフォームの話は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#7-crate-layout)の 7 章と 8 章にあります（英語）。
+どのサンプルページも同じ wasm ビルドで、どれを描くかは URL で伝えています。wgpu の道筋は [shader](/ja/examples/shader)、HTTP でのフォント取得は[font](/ja/examples/font) です。ランナーとプラットフォームの話は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#7-crate-layout)の 7 章と 8 章にあります（英語）。

--- a/site/ja/how-it-works.md
+++ b/site/ja/how-it-works.md
@@ -71,4 +71,4 @@ UI に構造があるときに使ってください。フォーム、パネル�
 
 ## もっと読む
 
-いちばん小さいサンプルは [counter](/ja/examples/counter) です。[notes](/ja/examples/notes) はライブラリのほとんどを一度に使います。ランタイムの詳細は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md)の 2 章と 5 章にあります（英語）。
+いちばん小さいサンプルは [counter](/ja/examples/counter) です。[notes](/ja/examples/notes) はライブラリのほとんどを一度に使います。ランタイムの詳細は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md)の 2 章と 5 章にあります（英語）。

--- a/site/ja/index.md
+++ b/site/ja/index.md
@@ -16,7 +16,7 @@ hero:
       link: /ja/examples/
     - theme: alt
       text: GitHub
-      link: https://github.com/fand/egui-react
+      link: https://github.com/fand/egui-reactor
 ---
 
 <script setup>

--- a/site/ja/reference/elements.md
+++ b/site/ja/reference/elements.md
@@ -363,4 +363,4 @@ prop の名前は `on_paint` ではなく `paint` です。`rsx!` は `on_` で�
 
 ## もっと知る
 
-要素の一覧と、それぞれのラッパーを作った理由は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#elements-list-egui-reactor-elements)の 6 章にあります（英語）。
+要素の一覧と、それぞれのラッパーを作った理由は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#elements-list-egui-reactor-elements)の 6 章にあります（英語）。

--- a/site/ja/reference/hooks.md
+++ b/site/ja/reference/hooks.md
@@ -217,4 +217,4 @@ pub fn use_previous<T: Clone + PartialEq + 'static>(cx: &mut Cx, value: T) -> Op
 
 ## もっと知る
 
-意味論の全体 ― id の作り方、衝突の検出、掃除がすること、順序の保証 ― は[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#4-hooks-list)の 4 章にあります（英語）。
+意味論の全体 ― id の作り方、衝突の検出、掃除がすること、順序の保証 ― は[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#4-hooks-list)の 4 章にあります（英語）。

--- a/site/ja/reference/layout-attributes.md
+++ b/site/ja/reference/layout-attributes.md
@@ -105,4 +105,4 @@ fn Chip(cx: &mut Cx, #[prop(default)] style: ItemStyle, label: &str) {
 
 ## もっと知る
 
-属性の完全な一覧、taffy への対応づけ、`<VirtualList>` の行の中で各属性がどうなるかは[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#layout-attributes)の 6 章にあります（英語）。
+属性の完全な一覧、taffy への対応づけ、`<VirtualList>` の行の中で各属性がどうなるかは[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#layout-attributes)の 6 章にあります（英語）。

--- a/site/reference/elements.md
+++ b/site/reference/elements.md
@@ -417,5 +417,5 @@ DOM mirror described in [Web and native](/guide/web-and-native).
 ## More
 
 The elements list with the reasoning behind each wrapper is in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#elements-list-egui-reactor-elements)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#elements-list-egui-reactor-elements)
 section 6.

--- a/site/reference/hooks.md
+++ b/site/reference/hooks.md
@@ -274,5 +274,5 @@ a `Dispatch`.
 
 The semantics in full — id derivation, collision detection, what the sweep
 does, the exact ordering guarantees — are in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#4-hooks-list)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#4-hooks-list)
 section 4.

--- a/site/reference/layout-attributes.md
+++ b/site/reference/layout-attributes.md
@@ -129,5 +129,5 @@ hatches take.
 
 The full attribute list, the taffy mapping, and what happens to each attribute
 inside a `<VirtualList>` row are in
-[docs/ARCHITECTURE.md](https://github.com/fand/egui-react/blob/main/docs/ARCHITECTURE.md#layout-attributes)
+[docs/ARCHITECTURE.md](https://github.com/fand/egui-reactor/blob/main/docs/ARCHITECTURE.md#layout-attributes)
 section 6.


### PR DESCRIPTION
## Summary

The repo is now `fand/egui-reactor`. Point every live URL and the GitHub Pages base at the new name.

## Changes

- Changed `github.com/fand/egui-react` to `egui-reactor` in `Cargo.toml`, README, site and `docs/ARCHITECTURE.md`
- Changed `fand.github.io/egui-react/` to `egui-reactor/` in README, site and docs
- Changed `SITE_BASE` in `pages.yml` to `/egui-reactor/`, and the comments that describe it
- Kept ADRs and `docs/tasks/` on their old links (historical; GitHub redirects)
- Kept the Cloudflare Pages project name `egui-react`